### PR TITLE
Adding support for port overrides

### DIFF
--- a/eapilib.go
+++ b/eapilib.go
@@ -40,6 +40,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -107,7 +108,7 @@ func (conn *EapiConnection) getURL() string {
 	if conn == nil {
 		return ""
 	}
-	url := conn.transport + "://" + conn.auth + "@" + conn.host + "/command-api"
+	url := conn.transport + "://" + conn.auth + "@" + conn.host + ":" + strconv.Itoa(conn.port) + "/command-api"
 	return url
 }
 
@@ -306,6 +307,9 @@ const DefaultHTTPLocalPort = 8080
 //  Newly created SocketEapiConnection
 func NewHTTPLocalEapiConnection(transport string, host string, username string,
 	password string, port int) EapiConnectionEntity {
+	if port == UseDefaultPortNum {
+		port = DefaultHTTPLocalPort
+	}
 	conn := EapiConnection{transport: transport, host: host, port: port, timeOut: 60}
 	return &HTTPLocalEapiConnection{conn}
 }
@@ -492,7 +496,9 @@ const DefaultHTTPSPath = "/command-api"
 //  Newly created HTTPSEapiConnection
 func NewHTTPSEapiConnection(transport string, host string, username string,
 	password string, port int) EapiConnectionEntity {
-	port = DefaultHTTPSPort
+	if port == UseDefaultPortNum {
+		port = DefaultHTTPSPort
+	}
 	path := DefaultHTTPSPath
 
 	conn := EapiConnection{transport: transport, host: host, port: port, timeOut: 60}


### PR DESCRIPTION
Overriding tcp ports for http/https eapi connections in configuration is not currently supported for goeapi. This diff adds support for port overrides.

I'm not super happy with concatenating the port number to the url generated the `EapiConnection.getURL()` method, regardless of whether it is the default port number or not, but it seemed like the simplest approach. Let me know if there is a better way, as I'm a bit of a golang n00b.