### PR TITLE
Return Node on call to Connect()

### DIFF
--- a/client.go
+++ b/client.go
@@ -669,7 +669,7 @@ func ConnectTo(name string) (*Node, error) {
 	return node, nil
 }
 
-// Connect creates a connection using the supplied settings
+// Connect establishes a connection (using the supplied settings) and creates a Node instance.
 //
 // This function will create a connection to an Arista EOS node using
 // the arguments.  All arguments are optional with default values.
@@ -692,14 +692,35 @@ func ConnectTo(name string) (*Node, error) {
 //  An instance of Node object for the specified transport.
 func Connect(transport string, host string, username string, passwd string,
 	port int) (*Node, error) {
-	conn, err := connect(transport, host, username, passwd, port)
+	conn, err := Connection(transport, host, username, passwd, port)
 	if err != nil {
 		return nil, err
 	}
 	return &Node{conn: conn, autoRefresh: true}, nil
 }
 
-func connect(transport string, host string, username string, passwd string,
+// Connection creates a connection using the supplied settings
+//
+// This function will create a connection to an Arista EOS node using
+// the arguments.  All arguments are optional with default values.
+//
+// Args:
+//  transport (string): Specifies the type of connection transport to use.
+//                   Valid values for the connection are socket, http_local,
+//                   http, and https.  https is the default.
+//  host (string): The IP addres or DNS host name of the connection device.
+//              The default value is 'localhost'
+//  username (string): The username to pass to the device to authenticate
+//                  the eAPI connection.   The default value is 'admin'
+//  password (string): The password to pass to the device to authenticate
+//                  the eAPI connection.  The default value is ''
+//  port (int): The TCP port of the endpoint for the eAPI connection.  If
+//              this keyword is not specified, the default value is
+//              automatically determined by the transport type.
+//              (http=80, https=443)
+// Returns:
+//  An instance of EapiConnectionEntity object for the specified transport.
+func Connection(transport string, host string, username string, passwd string,
 	port int) (EapiConnectionEntity, error) {
 	if transport == "" {
 		transport = "https"

--- a/client.go
+++ b/client.go
@@ -661,11 +661,12 @@ func ConnectTo(name string) (*Node, error) {
 	if ok {
 		port, _ = strconv.Atoi(section["port"])
 	}
-	conn, err := Connect(transport, host, username, passwd, port)
+	node, err := Connect(transport, host, username, passwd, port)
 	if err != nil {
 		return nil, err
 	}
-	return &Node{conn: conn, enablePasswd: enablepwd, autoRefresh: true}, nil
+	node.EnableAuthentication(enablepwd)
+	return node, nil
 }
 
 // Connect creates a connection using the supplied settings
@@ -676,8 +677,7 @@ func ConnectTo(name string) (*Node, error) {
 // Args:
 //  transport (string): Specifies the type of connection transport to use.
 //                   Valid values for the connection are socket, http_local,
-//                   http, and https.  The default value is specified
-//                   in DEFAULT_TRANSPORT
+//                   http, and https.  https is the default.
 //  host (string): The IP addres or DNS host name of the connection device.
 //              The default value is 'localhost'
 //  username (string): The username to pass to the device to authenticate
@@ -689,8 +689,17 @@ func ConnectTo(name string) (*Node, error) {
 //              automatically determined by the transport type.
 //              (http=80, https=443)
 // Returns:
-//  An instance of an EapiConnectionEntity object for the specified transport.
+//  An instance of Node object for the specified transport.
 func Connect(transport string, host string, username string, passwd string,
+	port int) (*Node, error) {
+	conn, err := connect(transport, host, username, passwd, port)
+	if err != nil {
+		return nil, err
+	}
+	return &Node{conn: conn, autoRefresh: true}, nil
+}
+
+func connect(transport string, host string, username string, passwd string,
 	port int) (EapiConnectionEntity, error) {
 	if transport == "" {
 		transport = "https"

--- a/client_test.go
+++ b/client_test.go
@@ -460,15 +460,13 @@ func TestClientConnectInvalidTransport_UnitTest(t *testing.T) {
 }
 
 func TestClientConnectTimeout_UnitTest(t *testing.T) {
-	node := &Node{}
-
 	// 1.1.1.2 is assumed to be an unreachable bogus address
-	conn, err := Connect("http", "1.1.1.2", "admin", "admin", 80)
+	node, err := Connect("http", "1.1.1.2", "admin", "admin", 80)
 	if err != nil {
 		t.Fatal("Error in connect.")
 	}
-	conn.SetTimeout(5)
-	node.SetConnection(conn)
+	node.GetConnection().SetTimeout(5)
+
 	if _, err = node.GetConfig("running-config", "all"); err == nil {
 		t.Fatal("Should timeout and return error")
 	}


### PR DESCRIPTION
Addresses issue #9 
Most all api calls require a Node instance to perform any functional action on the device. It doesn't make sense to return EapiConnetionEntity from a call to Connect(). Instead, we should return Node.

- Change Connect() to return Node
- Create Connection() call to create a connection and return EapiConnetionEntity.