### PR TITLE
Add default port to HTTP conn. Fix lint errors. DefaultPort test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,14 @@ EXTERNAL_TOOLS=\
 
 PKGS := $(shell go list ./... | grep -v /examples)
 
-ifndef GOBIN
-	GOBIN = $(GOPATH)/bin
-endif
-
-GOLINT := $(GOBIN)/golint
+GOLINT := golint
 
 all: install
 
 install:
 	$(GO) install $(PKGS)
 
-test: unittest vet
+test: vet unittest
 
 systest:
 	$(GOFOLDERS) | xargs $(GO) test $(GOTEST_FLAGS) -timeout=$(TEST_TIMEOUT) -run SystemTest$

--- a/client.go
+++ b/client.go
@@ -159,7 +159,7 @@ func GetHandle(n *Node, encoding string) (*EapiReqHandle, error) {
 		return nil, fmt.Errorf("Invalid encoding specified: %s", encoding)
 	}
 	if n == nil {
-		return nil, fmt.Errorf("Invalid node.")
+		return nil, fmt.Errorf("Invalid node")
 	}
 	return &EapiReqHandle{node: n, encoding: encoding}, nil
 }
@@ -230,7 +230,7 @@ func (n *Node) GetSection(regex string, config string) (string, error) {
 	}
 	sectionRegex, err := regexp.Compile(regex)
 	if err != nil {
-		return "", fmt.Errorf("Invalid regexp.")
+		return "", fmt.Errorf("Invalid regexp")
 	}
 	config, err = n.getConfigText(config, params)
 	if err != nil || config == "" {
@@ -507,7 +507,7 @@ func Connections() []string {
 func (e *EapiConfig) Read(filename string) error {
 	file, err := ini.LoadFile(filename)
 	if err != nil {
-		return fmt.Errorf("Cant read filename: %s, %#v\n", filename, err)
+		return fmt.Errorf("Cant read filename: %s, %#v", filename, err)
 	}
 	e.File = file
 

--- a/client_test.go
+++ b/client_test.go
@@ -474,6 +474,29 @@ func TestClientConnectTimeout_UnitTest(t *testing.T) {
 	}
 }
 
+func TestClientConnectDefaultPort_UnitTest(t *testing.T) {
+	tests := [...]struct {
+		proto string
+		port  int
+		descr string
+	}{
+		{"http", UseDefaultPortNum, "Http default port"},
+		{"http", 80, "Http port 80"},
+		{"https", UseDefaultPortNum, "Https default port"},
+		{"https", 443, "Https port 443"},
+		{"http_local", UseDefaultPortNum, "Http_local default port"},
+		{"http_local", 8080, "Http_local port 8080"},
+	}
+
+	for idx, tt := range tests {
+		// 1.1.1.2 is assumed to be an unreachable bogus address
+		_, err := Connect(tt.proto, "1.1.1.2", "admin", "admin", tt.port)
+		if err != nil {
+			t.Fatalf("Test[%d] %s. Error in connect: err:%#v", idx, tt.descr, err)
+		}
+	}
+}
+
 func TestClientNodeEnablePasswd_UnitTest(t *testing.T) {
 	node := &Node{}
 	node.EnableAuthentication("root")

--- a/eapi.go
+++ b/eapi.go
@@ -124,10 +124,10 @@ func debugJSON(data []byte) {
 // EapiReqHandle
 func (handle *EapiReqHandle) checkHandle() error {
 	if handle == nil {
-		return fmt.Errorf("Invalid EapiReqHandle.")
+		return fmt.Errorf("Invalid EapiReqHandle")
 	}
 	if handle.node == nil {
-		return fmt.Errorf("No connection.")
+		return fmt.Errorf("No connection")
 	}
 	return nil
 }
@@ -148,7 +148,7 @@ func AddCommandStr(handle *EapiReqHandle, command string, v EapiCommand) error {
 		return err
 	}
 	if command == "" {
-		handle.err = fmt.Errorf("Invalid null Command string.")
+		handle.err = fmt.Errorf("Invalid null Command string")
 		return handle.err
 	}
 
@@ -283,7 +283,7 @@ func (handle *EapiReqHandle) Close() error {
 // proper handling of the handle after the close.
 func Close(handle *EapiReqHandle) error {
 	if handle == nil {
-		return fmt.Errorf("Invalid EapiReqHandle.")
+		return fmt.Errorf("Invalid EapiReqHandle")
 	}
 	handle.clearCommands()
 	handle.node = nil

--- a/eapilib.go
+++ b/eapilib.go
@@ -364,7 +364,8 @@ type HTTPEapiConnection struct {
 	EapiConnection
 }
 
-const defaultHTTPPort = 80
+// DefaultHTTPPort uses 80
+const DefaultHTTPPort = 80
 
 // NewHTTPEapiConnection initializes a HttpEapiConnection.
 //
@@ -381,7 +382,9 @@ const defaultHTTPPort = 80
 //  Newly created HTTPEapiConnection
 func NewHTTPEapiConnection(transport string, host string, username string,
 	password string, port int) EapiConnectionEntity {
-	port = defaultHTTPPort
+	if port == UseDefaultPortNum {
+		port = DefaultHTTPPort
+	}
 	conn := EapiConnection{transport: transport, host: host, port: port, timeOut: 60}
 	conn.Authentication(username, password)
 	return &HTTPEapiConnection{conn}


### PR DESCRIPTION
- Add port select logic to HTTP conn.
- Fix lint errors related to error messages with ending punctuation
- Add Port select test