### PR TITLE
add `show arp` command

### DIFF
--- a/module/arp.go
+++ b/module/arp.go
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2015-2016, Arista Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+//   * Neither the name of Arista Networks nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+// IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+package module
+
+type ShowARP struct {
+	DynamicEntries    int            `json:"dynamicEntries"`
+	IPv4Neighbors     []IPv4Neighbor `json:"ipV4Neighbors"`
+	NotLearnedEntries int            `json:"notLearnedEntries"`
+	TotalEntries      int            `json:"totalEntries"`
+	StaticEntries     int            `json:"staticEntries"`
+}
+
+type IPv4Neighbor struct {
+	HWAddress string `json:"hwAddress"`
+	Address   string `json:"address"`
+	Interface string `json:"interface"`
+	Age       int    `json:"age"`
+}
+
+func (a *ShowARP) GetCmd() string {
+	return "show arp"
+}
+
+func (s *ShowEntity) ShowARP() (ShowARP, error) {
+	var showarp ShowARP
+
+	handle, err := s.node.GetHandle("json")
+	if err != nil {
+		return showarp, err
+	}
+
+	err = handle.AddCommand(&showarp)
+	if err != nil {
+		return showarp, err
+	}
+
+	if err := handle.Call(); err != nil {
+		return showarp, err
+	}
+
+	handle.Close()
+	return showarp, nil
+}

--- a/module/arp_test.go
+++ b/module/arp_test.go
@@ -1,0 +1,66 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+func TestShowARP_UnitTest(t *testing.T) {
+	var dummyNode *goeapi.Node
+	var dummyConnection *DummyConnection
+
+	dummyConnection = &DummyConnection{}
+
+	dummyNode = &goeapi.Node{}
+	dummyNode.SetConnection(dummyConnection)
+
+	show := Show(dummyNode)
+	showArp, err := show.ShowARP()
+	if err != nil {
+		t.Errorf("Error during Show ARP, %s", err)
+	}
+
+	var scenarios = []struct {
+		HWAddress string
+		Address   string
+		Interface string
+	}{
+		{
+			HWAddress: "444c.a8aa.bbcc",
+			Address:   "10.10.10.10",
+			Interface: "Ethernet1/1",
+		},
+		{
+			HWAddress: "444c.a8bb.ccdd",
+			Address:   "10.10.10.20",
+			Interface: "Ethernet2/1",
+		},
+		{
+			HWAddress: "444c.a8cc.ddee",
+			Address:   "10.10.10.30",
+			Interface: "Ethernet3/1",
+		},
+		{
+			HWAddress: "444c.a8dd.eeff",
+			Address:   "10.10.10.40",
+			Interface: "Ethernet4/1",
+		},
+	}
+
+	neighbors := showArp.IPv4Neighbors
+
+	for i, tt := range scenarios {
+		if tt.HWAddress != neighbors[i].HWAddress {
+			t.Errorf("HWAddress does not match expected %s, got %s", tt.HWAddress, neighbors[i].HWAddress)
+		}
+
+		if tt.Address != neighbors[i].Address {
+			t.Errorf("Address does not match expected %s, got %s", tt.Address, neighbors[i].Address)
+		}
+
+		if tt.Interface != neighbors[i].Interface {
+			t.Errorf("Interface does not match expected %s, got %s", tt.Interface, neighbors[i].Interface)
+		}
+	}
+}

--- a/testdata/fixtures/show_arp.json
+++ b/testdata/fixtures/show_arp.json
@@ -1,0 +1,39 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    {},
+    {
+      "dynamicEntries": 4,
+      "ipV4Neighbors": [
+        {
+          "hwAddress": "444c.a8aa.bbcc",
+          "address": "10.10.10.10",
+          "interface": "Ethernet1/1",
+          "age": 0
+        },
+        {
+          "hwAddress": "444c.a8bb.ccdd",
+          "address": "10.10.10.20",
+          "interface": "Ethernet2/1",
+          "age": 0
+        },
+        {
+          "hwAddress": "444c.a8cc.ddee",
+          "address": "10.10.10.30",
+          "interface": "Ethernet3/1",
+          "age": 0
+        },
+        {
+          "hwAddress": "444c.a8dd.eeff",
+          "address": "10.10.10.40",
+          "interface": "Ethernet4/1",
+          "age": 0
+        }
+      ],
+      "notLearnedEntries": 0,
+      "totalEntries": 4,
+      "staticEntries": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add `show arp` command module


We are working on getting a lot of information from our devices to update/keep up to date our other inventory systems, so there will be most likely a bunch of more updates from me specifically around `show` commands.

Do you think there is any better way to do this, or does creating show commands under like `arp` or `lldp` makes sense. The next one I will probably be targeting is `show ip bgp summary`

I believe it makes sense to go under `ip.go`? However its about BGP so maybe it makes sense to go under `bgp.go`. Thoughts?