### PR TITLE
Add IPRoute module

### DIFF
--- a/module/dummy_connection_test.go
+++ b/module/dummy_connection_test.go
@@ -1,0 +1,57 @@
+package module
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+type DummyConnection struct {
+	goeapi.EapiConnection
+	err error
+}
+
+func (conn *DummyConnection) Execute(commands []interface{},
+	encoding string) (*goeapi.JSONRPCResponse, error) {
+
+	if encoding != "json" {
+		return nil, fmt.Errorf("%s encoding not implemented", encoding)
+	}
+
+	if conn.err != nil {
+		conn.SetError(conn.err)
+		return &goeapi.JSONRPCResponse{}, conn.err
+	}
+	// command 0: enable
+	// command 1: show lldp neighbors
+	cmd := commands[1].(string)
+	fixtureName := strings.Replace(cmd, " ", "_", -1) + ".json"
+	// cmd: 'show lldp neighbors' will cause us to look for
+	// fixture 'show_lldp_neighbors.json'
+	r, err := os.Open(GetFixture(fixtureName))
+	if err != nil {
+		return nil, fmt.Errorf("Error opening fixture: %s", err)
+	}
+	defer r.Close()
+	return conn.decodeJSONFile(r), nil
+}
+
+func (conn *DummyConnection) SetTimeout(uint32) {
+}
+
+func (conn *DummyConnection) Error() error {
+	return conn.err
+}
+
+func (conn *DummyConnection) decodeJSONFile(r io.Reader) *goeapi.JSONRPCResponse {
+	dec := json.NewDecoder(r)
+	var v goeapi.JSONRPCResponse
+	if err := dec.Decode(&v); err != nil {
+		panic(err)
+	}
+	return &v
+}

--- a/module/iproute.go
+++ b/module/iproute.go
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2015-2016, Arista Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+//   * Neither the name of Arista Networks nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+// IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+package module
+
+type ShowIPRoute struct {
+	VRFs map[string]Routes `json:"vrfs"`
+}
+
+type Routes struct {
+	Routes map[string]Route `json:"routes"`
+}
+
+type Route struct {
+	KernelProgrammed  bool   `json:"kernelProgrammed"`
+	DirectlyConnected bool   `json:"directlyConnected"`
+	Preference        int    `json:"preference"`
+	RouteAction       string `json:"routeAction"`
+	Vias              []struct {
+		Interface   string `json:"interface"`
+		NexthopAddr string `json:"nexthopAddr"`
+	} `json:"vias"`
+	Metric             int    `json:"metric"`
+	HardwareProgrammed bool   `json:"hardwareProgrammed"`
+	RouteType          string `json:"routeType"`
+}
+
+func (r *ShowIPRoute) GetCmd() string {
+	return "show ip route"
+}
+
+func (s *ShowEntity) ShowIPRoute() ShowIPRoute {
+	handle, _ := s.node.GetHandle("json")
+	var showiproute ShowIPRoute
+	handle.AddCommand(&showiproute)
+	handle.Call()
+	handle.Close()
+	return showiproute
+}

--- a/module/iproute_test.go
+++ b/module/iproute_test.go
@@ -1,0 +1,51 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+func TestShowIPRoute_UnitTest(t *testing.T) {
+	var dummyNode *goeapi.Node
+	var dummyConnection *DummyConnection
+
+	dummyConnection = &DummyConnection{}
+
+	dummyNode = &goeapi.Node{}
+	dummyNode.SetConnection(dummyConnection)
+
+	show := Show(dummyNode)
+	showIPRoute := show.ShowIPRoute()
+
+	var scenarios = []struct {
+		Route             string
+		DirectlyConnected bool
+		RouteType         string
+	}{
+		{
+			Route:             "10.1.2.0/20",
+			DirectlyConnected: true,
+			RouteType:         "connected",
+		},
+		{
+			Route:             "0.0.0.0/0",
+			DirectlyConnected: false,
+			RouteType:         "static",
+		},
+	}
+
+	defaultVrfRoutes := showIPRoute.VRFs["default"].Routes
+
+	for _, tt := range scenarios {
+		r := defaultVrfRoutes[tt.Route]
+
+		if tt.DirectlyConnected != r.DirectlyConnected {
+			t.Errorf("DirectlyConnected does not match expected %t, got %t", tt.DirectlyConnected, r.DirectlyConnected)
+		}
+
+		if tt.RouteType != r.RouteType {
+			t.Errorf("RouteType does not match expected %s, got %s", tt.RouteType, r.RouteType)
+		}
+	}
+}

--- a/module/lldp_test.go
+++ b/module/lldp_test.go
@@ -1,61 +1,10 @@
 package module
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/aristanetworks/goeapi"
 )
-
-type DummyConnection struct {
-	goeapi.EapiConnection
-	err error
-}
-
-func (conn *DummyConnection) Execute(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
-
-	if encoding != "json" {
-		return nil, fmt.Errorf("%s encoding not implemented", encoding)
-	}
-
-	if conn.err != nil {
-		conn.SetError(conn.err)
-		return &goeapi.JSONRPCResponse{}, conn.err
-	}
-	// command 0: enable
-	// command 1: show lldp neighbors
-	cmd := commands[1].(string)
-	fixtureName := strings.Replace(cmd, " ", "_", -1) + ".json"
-	// cmd: 'show lldp neighbors' will cause us to look for
-	// fixture 'show_lldp_neighbors.json'
-	r, err := os.Open(GetFixture(fixtureName))
-	if err != nil {
-		return nil, fmt.Errorf("Error opening fixture: %s", err)
-	}
-	defer r.Close()
-	return conn.decodeJSONFile(r), nil
-}
-
-func (conn *DummyConnection) SetTimeout(uint32) {
-}
-
-func (conn *DummyConnection) Error() error {
-	return conn.err
-}
-
-func (conn *DummyConnection) decodeJSONFile(r io.Reader) *goeapi.JSONRPCResponse {
-	dec := json.NewDecoder(r)
-	var v goeapi.JSONRPCResponse
-	if err := dec.Decode(&v); err != nil {
-		panic(err)
-	}
-	return &v
-}
 
 func TestShowLLDPNeighbors_UnitTest(t *testing.T) {
 	var dummyNode *goeapi.Node

--- a/testdata/fixtures/show_ip_route.json
+++ b/testdata/fixtures/show_ip_route.json
@@ -1,0 +1,46 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    {},
+    {
+      "vrfs": {
+        "default": {
+          "routes": {
+            "10.1.2.0/20": {
+              "kernelProgrammed": true,
+              "directlyConnected": true,
+              "routeAction": "forward",
+              "vias": [
+                {
+                  "interface": "Vlan1"
+                }
+              ],
+              "hardwareProgrammed": true,
+              "routeType": "connected"
+            },
+            "0.0.0.0/0": {
+              "kernelProgrammed": true,
+              "directlyConnected": false,
+              "preference": 1,
+              "routeAction": "forward",
+              "vias": [
+                {
+                  "interface": "Vlan1",
+                  "nexthopAddr": "10.1.2.1"
+                }
+              ],
+              "metric": 0,
+              "hardwareProgrammed": true,
+              "routeType": "static"
+            }
+          },
+          "allRoutesProgrammedKernel": true,
+          "routingDisabled": true,
+          "allRoutesProgrammedHardware": true,
+          "defaultRouteState": "reachable"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Without this change, there is not an easy show module for getting the routes
from a device.  Here we implement the minimum feature set for using the show
module.