### PR TITLE
add ptp module

### DIFF
--- a/module/ptp.go
+++ b/module/ptp.go
@@ -1,0 +1,304 @@
+package module
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+//
+// Copyright (c) 2015-2016, Arista Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+//   * Neither the name of Arista Networks nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+// IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+// PtpConfig represents the parsed ptp config
+type PtpConfig struct {
+	sourceIP string
+	mode     string
+	ttl      string
+}
+
+// SourceIP returns source ip address of ptp packets sent by this node
+func (p *PtpConfig) SourceIP() string {
+	return p.sourceIP
+}
+
+// Mode returns ptp mode, either dynamic or master, which this node operates
+func (p *PtpConfig) Mode() string {
+	return p.mode
+}
+
+// TTL returns time to leave number sent in ipv4 header
+func (p *PtpConfig) TTL() string {
+	return p.ttl
+}
+
+// PTPEntity provides a configuration resource for ptp
+type PTPEntity struct {
+	interfaces *PTPInterfaceEntity
+	*AbstractBaseEntity
+}
+
+// Interfaces returns the STPInterfaces instance
+func (p *PTPEntity) Interfaces() *PTPInterfaceEntity {
+	if p.interfaces == nil {
+		p.interfaces = PTPInterfaces(p.AbstractBaseEntity.node)
+	}
+	return p.interfaces
+}
+
+// Ptp factory function to initiallize PTPEntity resource
+// given a Node
+func Ptp(node *goeapi.Node) *PTPEntity {
+	return &PTPEntity{AbstractBaseEntity: &AbstractBaseEntity{node}}
+}
+
+// Get the PTP Config for the current entity.
+// Returns a Ptponfig object
+func (p *PTPEntity) Get() *PtpConfig {
+	config := p.Config()
+
+	var ptp = new(PtpConfig)
+	ptp.sourceIP = p.parse(config, "source ip")
+	ptp.mode = p.parse(config, "mode")
+	ptp.ttl = p.parse(config, "ttl")
+
+	return ptp
+}
+
+// ConfigurePtp configures the PTP Entity with the given
+// command. Returns true (bool) if the commands complete
+// successfully
+func (p *PTPEntity) ConfigurePtp(cmd string) bool {
+	config := p.Get()
+	if config == nil {
+		return false
+	}
+	commands := []string{
+		cmd,
+	}
+	return p.Configure(commands...)
+}
+
+// SetSourceIP configures the source ip using the provided value.
+// Returns true(bool) if the commands complete successfully
+func (p *PTPEntity) SetSourceIP(value string) bool {
+	if value == "" {
+		return p.ConfigurePtp("no ptp source ip")
+	}
+	return p.ConfigurePtp("ptp source ip " + value)
+}
+
+// SetMode configures the ptp mode using the provided value.
+// Returns true(bool) if the commands complete successfully
+func (p *PTPEntity) SetMode(value string) bool {
+	if value == "" {
+		return p.ConfigurePtp("no ptp mode")
+	}
+	return p.ConfigurePtp("ptp mode " + value)
+}
+
+// SetTTL configures the ptp ttl using the provided value.
+// Returns true(bool) if the commands complete successfully
+func (p *PTPEntity) SetTTL(value string) bool {
+	if value == "" {
+		return p.ConfigurePtp("no ptp ttl")
+	}
+	return p.ConfigurePtp("ptp ttl " + value)
+}
+
+// parse parses the given PTP config for the give pattern value
+func (p *PTPEntity) parse(config string, pattern string) string {
+	str := fmt.Sprintf(`(?m)ptp %s ([^\s]+)`, pattern)
+	re := regexp.MustCompile(str)
+	match := re.FindStringSubmatch(config)
+	if match == nil {
+		return ""
+	}
+	return match[1]
+}
+
+// PTPInterfaceConfig represents the parsed PTP interface config
+// {
+//		"enabled"     : "true",
+//		"role"        : "dynamic",
+//		"transport"   : "layer2",
+// }
+type PTPInterfaceConfig map[string]string
+
+// PTPInterfaceCollection is a collection of PTPInterfaceConfigs
+// mapped by interface name:
+// {
+//		"Ethernet49/1" : PTPInterfaceConfig {
+//							"enabled"   : "false",
+//							"role"      : "dynamic",
+//							"transport" : "layer2",
+//						  },
+//		   "Ethernet1" : ...
+// }
+type PTPInterfaceCollection map[string]PTPInterfaceConfig
+
+// PTPInterfaceEntity provides a configuration resource for PTP
+type PTPInterfaceEntity struct {
+	*AbstractBaseEntity
+}
+
+// PTPInterfaces factory function to initiallize PTPInterfaceEntity resource
+// given a Node
+func PTPInterfaces(node *goeapi.Node) *PTPInterfaceEntity {
+	return &PTPInterfaceEntity{&AbstractBaseEntity{node}}
+}
+
+// Get returns an PTPInterfaceConfig type for a given interface name(string).
+func (p *PTPInterfaceEntity) Get(name string) PTPInterfaceConfig {
+	parent := `interface\s+` + name
+	config, _ := p.GetBlock(parent)
+
+	return PTPInterfaceConfig{
+		"enabled":   strconv.FormatBool(p.parsePTPEnabled(config)),
+		"role":      p.parsePTPRole(config),
+		"transport": p.parsePTPTransport(config),
+	}
+}
+
+// GetPTPAdminStatus returns "true" if ptp enabled on this interfaces
+func (p PTPInterfaceConfig) GetPTPAdminStatus() string {
+	return p["enabled"]
+}
+
+// GetAll returns a collection of PTPInterfaceConfigs key'd by
+// interface name.
+func (p *PTPInterfaceEntity) GetAll() PTPInterfaceCollection {
+	config := p.Config()
+
+	re := regexp.MustCompile(`(?m)^interface\s(Eth.+|Po.+)$`)
+	interfaces := re.FindAllStringSubmatch(config, -1)
+
+	collection := make(PTPInterfaceCollection)
+
+	for _, matchedLine := range interfaces {
+		intf := matchedLine[1]
+		if tmp := p.Get(intf); tmp != nil {
+			collection[intf] = tmp
+		}
+	}
+	return collection
+}
+
+// parsePTPEnabled parses the provided interface config returning
+// true(bool) if ptp is enabled
+func (p *PTPInterfaceEntity) parsePTPEnabled(config string) bool {
+	matched, _ := regexp.MatchString(`(?m)^\s+ptp enable`, config)
+	return matched
+}
+
+// parsePTPRole parses the provided interface config returning the
+// ptp role (dynamic, master)
+func (p *PTPInterfaceEntity) parsePTPRole(config string) string {
+	found, _ := regexp.MatchString("ptp mode master", config)
+	if found {
+		return "master"
+	}
+	return "dynamic"
+}
+
+// parsePTPTransport parses the provided interface config returning the
+// ptp transport (ipv4, layer2)
+func (p *PTPInterfaceEntity) parsePTPTransport(config string) string {
+	found, _ := regexp.MatchString("ptp transport layer2", config)
+	if found {
+		return "layer2"
+	}
+	return "ipv4"
+}
+
+// SetEnable enables(true) or disables(false) ptp for the interface
+// name(string). Returns true(bool) if configuration successful
+func (p *PTPInterfaceEntity) SetEnable(name string, enable bool) bool {
+	str := "no ptp enable"
+	if enable {
+		str = "ptp enable"
+	}
+	cmd := p.CommandBuilder(str, "", false, true)
+	return p.ConfigureInterface(name, cmd)
+}
+
+// ShowPTP represents "show ptp" output
+type ShowPTP struct {
+	PtpMode          string             `json:"ptpMode"`
+	PtpClockSummary  PtpClockSummary    `json:"ptpClockSummary"`
+	PtpIntfSummaries map[string]PtpIntf `json:"ptpIntfSummaries"`
+}
+
+// PtpIntf represents inidividual interface in "show ptp" output
+type PtpIntf struct {
+	PortState      string `json:"portState"`
+	DelayMechanism string `json:"delayMechanism"`
+	TransportMode  string `json:"transportMode"`
+}
+
+// PtpClockSummary represents common data in "show ptp" output
+type PtpClockSummary struct {
+	ClockIdentity        string  `json:"clockIdentity"`
+	MeanPathDelay        int     `json:"meanPathDelay"`
+	StepsRemoved         int     `json:"stepsRemoved"`
+	Skew                 float64 `json:"skew"`
+	GmClockIdentity      string  `json:"gmClockIdentity"`
+	SlavePort            string  `json:"slavePort"`
+	NumberOfMasterPorts  int     `json:"numberOfMasterPorts"`
+	NumberOfSlavePorts   int     `json:"numberOfSlavePorts"`
+	CurrentPtpSystemTime int     `json:"currentPtpSystemTime"`
+	OffsetFromMaster     int     `json:"offsetFromMaster"`
+	LastSyncTime         int     `json:"lastSyncTime"`
+}
+
+func (b *ShowPTP) GetCmd() string {
+	return "show ptp"
+}
+
+func (s *ShowEntity) ShowPTP() (ShowPTP, error) {
+	var showptp ShowPTP
+	handle, err := s.node.GetHandle("json")
+	if err != nil {
+		return showptp, err
+	}
+	err = handle.AddCommand(&showptp)
+	if err != nil {
+		return showptp, err
+	}
+	err = handle.Call()
+	if err != nil {
+		return showptp, err
+	}
+	handle.Close()
+	return showptp, nil
+}

--- a/module/ptp_test.go
+++ b/module/ptp_test.go
@@ -1,0 +1,384 @@
+package module
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+/**
+ *****************************************************************************
+ * Unit Tests
+ *****************************************************************************
+ **/
+
+func TestPTPGet_UnitTest(t *testing.T) {
+	ptp := Ptp(dummyNode)
+	config := ptp.Get()
+	if config.SourceIP() != "1.1.1.1" || config.TTL() != "30" ||
+		config.Mode() != "boundary" {
+		t.Fatalf("Invalid result from Get(): %#v", config)
+	}
+}
+
+func TestPTPInterfaces_UnitTest(t *testing.T) {
+	ptp := Ptp(&goeapi.Node{})
+	i := ptp.Interfaces()
+	if i == nil {
+		t.Fatalf("No PTPInterfaces")
+	}
+}
+
+func TestPTPSetMode_UnitTest(t *testing.T) {
+	ptp := Ptp(dummyNode)
+
+	cmds := []string{
+		"default ptp mode",
+	}
+
+	tests := [...]struct {
+		mode string
+		want string
+		rc   bool
+	}{
+		{"boundary", "ptp mode boundary", true},
+		{"e2etransparent", "ptp mode e2etransparent", true},
+		{"p2ptransparent", "ptp mode p2ptransparent", true},
+		{"gptp", "ptp mode gptp", true},
+		{"", "no ptp mode", true},
+		{"disabled", "ptp mode disabled", true},
+	}
+
+	for _, tt := range tests {
+		if got := ptp.SetMode(tt.mode); got != tt.rc {
+			t.Fatalf("SetMode(%s) = %t; want %t", tt.mode, got, tt.rc)
+		}
+		if tt.rc {
+			cmds[0] = tt.want
+			// first two commands are 'enable', 'configure terminal'
+			commands := dummyConnection.GetCommands()[2:]
+			for idx, val := range commands {
+				if cmds[idx] != val {
+					t.Fatalf("Expected \"%q\" got \"%q\"", cmds, commands)
+				}
+			}
+		}
+	}
+}
+
+func TestPTPSetSourceIp_UnitTest(t *testing.T) {
+	ptp := Ptp(dummyNode)
+
+	cmds := []string{
+		"default ptp source ip",
+	}
+
+	tests := [...]struct {
+		mode string
+		want string
+		rc   bool
+	}{
+		{"1.1.1.1", "ptp source ip 1.1.1.1", true},
+		{"", "no ptp source ip", true},
+	}
+
+	for _, tt := range tests {
+		if got := ptp.SetSourceIP(tt.mode); got != tt.rc {
+			t.Fatalf("SetSourceIP(%s) = %t; want %t", tt.mode, got, tt.rc)
+		}
+		if tt.rc {
+			cmds[0] = tt.want
+			// first two commands are 'enable', 'configure terminal'
+			commands := dummyConnection.GetCommands()[2:]
+			for idx, val := range commands {
+				if cmds[idx] != val {
+					t.Fatalf("Expected \"%q\" got \"%q\"", cmds, commands)
+				}
+			}
+		}
+	}
+}
+
+func TestPTPSetTTL_UnitTest(t *testing.T) {
+	ptp := Ptp(dummyNode)
+
+	cmds := []string{
+		"default ptp ttl",
+	}
+
+	tests := [...]struct {
+		mode string
+		want string
+		rc   bool
+	}{
+		{"30", "ptp ttl 30", true},
+		{"300", "ptp ttl 300", true}, // must be false, invalid command for EOS, range is 1 to 2546
+		{"", "no ptp ttl", true},
+	}
+
+	for _, tt := range tests {
+		if got := ptp.SetTTL(tt.mode); got != tt.rc {
+			t.Fatalf("SetTTL(%s) = %t; want %t", tt.mode, got, tt.rc)
+		}
+		if tt.rc {
+			cmds[0] = tt.want
+			// first two commands are 'enable', 'configure terminal'
+			commands := dummyConnection.GetCommands()[2:]
+			for idx, val := range commands {
+				if cmds[idx] != val {
+					t.Fatalf("Expected \"%q\" got \"%q\"", cmds, commands)
+				}
+			}
+		}
+	}
+}
+
+func TestParse_UnitTest(t *testing.T) {
+	var p PTPEntity
+	shortConfig := `
+  no ip policy unresolved-nexthop action drop
+  no ip policy mac address aging
+  no ip policy match protocol bgp
+  !
+  power PowerSupply1 input voltage warning low 0.00 readings 10
+  power PowerSupply2 input voltage warning low 0.00 readings 10
+  !
+  power poll-interval 5
+  !
+  ptp priority1 128
+  ptp clock-identity 00:00:00:00:00:00:00:00
+  ptp priority2 128
+  ptp domain 0
+  ptp source ip 1.1.1.1
+  ptp mode boundary
+  ptp ttl 30
+  ptp message-type general dscp 0 default
+  ptp message-type event dscp 21 default
+  ptp hold-ptp-time 28800
+  no ptp forward-v1
+  no ptp forward-unicast
+  ptp monitor
+  no ptp monitor threshold offset-from-master
+  no ptp monitor threshold mean-path-delay
+  no ptp monitor threshold skew
+  !
+  ptp hardware-sync interval 1000
+  !
+  no radius-server key
+  radius-server timeout 5
+  radius-server retransmit 3
+  no radius-server deadtime
+  no radius-server attribute 32 include-in-access-req format
+  radius-server qos dscp 0
+`
+	tests := [...]struct {
+		in   string
+		want string
+	}{
+		{"mode", "boundary"},
+		{"source ip", "1.1.1.1"},
+		{"ttl", "30"},
+	}
+
+	for _, tt := range tests {
+		testConfig := fmt.Sprintf(shortConfig)
+		if got := p.parse(testConfig, tt.in); got != tt.want {
+			t.Fatalf("parse(config, %s) = %v; want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPTPIntfGet_UnitTest(t *testing.T) {
+	ptp := PTPInterfaces(dummyNode)
+	config := ptp.Get("Ethernet1")
+	for _, val := range []string{"enabled", "role", "transport"} {
+		if _, found := config[val]; !found {
+			t.Fatalf("Get() missing key %s", val)
+		}
+	}
+}
+
+func TestPTPIntfGetAll_UnitTest(t *testing.T) {
+	ptp := PTPInterfaces(dummyNode)
+	interfaces := ptp.GetAll()
+	for _, val := range []string{"enabled", "role", "transport"} {
+		if _, found := interfaces["Ethernet1"][val]; !found {
+			t.Fatalf("Get() missing key %s", val)
+		}
+	}
+}
+
+func TestPTPIntfGetPTPAdminStatus_UnitTest(t *testing.T) {
+	ptp := PTPInterfaces(dummyNode)
+	tests := [...]struct {
+		in   string
+		want bool
+	}{
+		{"Ethernet1", true},
+		{"Ethernet2", false},
+		{"Ethernet3", false},
+	}
+	for _, tt := range tests {
+		intf := ptp.Get(tt.in)
+		if got, _ := strconv.ParseBool(intf.GetPTPAdminStatus()); got != tt.want {
+			t.Fatalf("%s.GetPTPAdminStatus() = %v; want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPTPIntfSetEnable_UnitTest(t *testing.T) {
+	ptp := PTPInterfaces(dummyNode)
+	tests := []struct {
+		in    string
+		value bool
+		want  string
+		rc    bool
+	}{
+		{"Ethernet2", true, "ptp enable", true},
+		{"Ethernet3", false, "no ptp enable", true},
+	}
+
+	for _, tt := range tests {
+		cmds := []string{
+			"interface " + tt.in,
+			"default ptp enable",
+		}
+
+		if ok := ptp.SetEnable(tt.in, tt.value); ok != tt.rc {
+			t.Fatalf("Expected status \"%t\" got \"%t\"", tt.rc, ok)
+		}
+		cmds[1] = tt.want
+		// first two commands are 'enable', 'configure terminal'
+		commands := dummyConnection.GetCommands()[2:]
+		for idx, val := range commands {
+			if cmds[idx] != val {
+				t.Fatalf("Expected \"%q\" got \"%q\"", cmds, commands)
+			}
+		}
+	}
+}
+
+func TestShowPTP_UnitTest(t *testing.T) {
+	var dummyNode *goeapi.Node
+	var dummyConnection *DummyConnection
+
+	dummyConnection = &DummyConnection{}
+
+	dummyNode = &goeapi.Node{}
+	dummyNode.SetConnection(dummyConnection)
+
+	show := Show(dummyNode)
+	showPTP, _ := show.ShowPTP()
+
+	type ClockSummary struct {
+		ClockIdentity        string
+		GmClockIdentity      string
+		SlavePort            string
+		NumberOfMasterPorts  int
+		NumberOfSlavePorts   int
+		CurrentPtpSystemTime int
+		OffsetFromMaster     int
+	}
+
+	type IntfSummary struct {
+		InterfaceName  string
+		PortState      string
+		DelayMechanism string
+		TransportMode  string
+	}
+
+	var scenarios = []struct {
+		PtpMode          string
+		PtpClockSummary  ClockSummary
+		PtpIntfSummaries []IntfSummary
+	}{
+		{
+			PtpMode: "ptpBoundaryClock",
+			PtpClockSummary: ClockSummary{
+				ClockIdentity:        "0x01:01:01:ff:ff:01:a0:01",
+				GmClockIdentity:      "0x01:01:01:ff:fe:01:a0:02",
+				SlavePort:            "Ethernet49/1",
+				NumberOfMasterPorts:  1,
+				NumberOfSlavePorts:   1,
+				CurrentPtpSystemTime: 1557315926,
+				OffsetFromMaster:     -10,
+			},
+			PtpIntfSummaries: []IntfSummary{
+				{
+					InterfaceName:  "Ethernet49/1",
+					PortState:      "psSlave",
+					DelayMechanism: "e2e",
+					TransportMode:  "ipv4",
+				},
+				{
+					InterfaceName:  "Ethernet53/1",
+					PortState:      "psMaster",
+					DelayMechanism: "e2e",
+					TransportMode:  "ipv4",
+				},
+			},
+		},
+	}
+
+	interfaces := showPTP.PtpIntfSummaries
+
+	for _, tt := range scenarios {
+		if tt.PtpMode != showPTP.PtpMode {
+			t.Errorf("Ptp mode does not match expected %s, got %s", tt.PtpMode,
+				showPTP.PtpMode)
+		}
+		if tt.PtpClockSummary.ClockIdentity != showPTP.PtpClockSummary.ClockIdentity {
+			t.Errorf("Ptp local clock identity does not match expected %s, got %s",
+				tt.PtpClockSummary.ClockIdentity,
+				showPTP.PtpClockSummary.ClockIdentity)
+		}
+		if tt.PtpClockSummary.GmClockIdentity != showPTP.PtpClockSummary.GmClockIdentity {
+			t.Errorf("Ptp grand master clock identity does not match expected %s, got %s",
+				tt.PtpClockSummary.GmClockIdentity,
+				showPTP.PtpClockSummary.GmClockIdentity)
+		}
+		if tt.PtpClockSummary.SlavePort != showPTP.PtpClockSummary.SlavePort {
+			t.Errorf("Ptp slave port not match expected %s, got %s",
+				tt.PtpClockSummary.SlavePort, showPTP.PtpClockSummary.SlavePort)
+		}
+		if tt.PtpClockSummary.OffsetFromMaster != showPTP.PtpClockSummary.OffsetFromMaster {
+			t.Errorf("Ptp offset from master not match expected %d, got %d",
+				tt.PtpClockSummary.OffsetFromMaster,
+				showPTP.PtpClockSummary.OffsetFromMaster)
+		}
+		if tt.PtpClockSummary.CurrentPtpSystemTime != showPTP.PtpClockSummary.CurrentPtpSystemTime {
+			t.Errorf("Ptp time not match expected %d, got %d",
+				tt.PtpClockSummary.CurrentPtpSystemTime,
+				showPTP.PtpClockSummary.CurrentPtpSystemTime)
+		}
+		if tt.PtpClockSummary.NumberOfMasterPorts != showPTP.PtpClockSummary.NumberOfMasterPorts {
+			t.Errorf("Number of master ports does not match expected %d, got %d",
+				tt.PtpClockSummary.NumberOfMasterPorts,
+				showPTP.PtpClockSummary.NumberOfMasterPorts)
+		}
+		if tt.PtpClockSummary.NumberOfSlavePorts != showPTP.PtpClockSummary.NumberOfSlavePorts {
+			t.Errorf("Number of slave ports does not match expected %d, got %d",
+				tt.PtpClockSummary.NumberOfSlavePorts,
+				showPTP.PtpClockSummary.NumberOfSlavePorts)
+		}
+		for _, intf := range tt.PtpIntfSummaries {
+			if intf.PortState != interfaces[intf.InterfaceName].PortState {
+				t.Errorf("State of the port %s does not match expected %s, got %s",
+					intf.InterfaceName, intf.PortState,
+					interfaces[intf.InterfaceName].PortState)
+			}
+			if intf.DelayMechanism != interfaces[intf.InterfaceName].DelayMechanism {
+				t.Errorf("Delay mechanism of the port %s does not match expected %s, got %s",
+					intf.InterfaceName, intf.DelayMechanism,
+					interfaces[intf.InterfaceName].DelayMechanism)
+			}
+			if intf.TransportMode != interfaces[intf.InterfaceName].TransportMode {
+				t.Errorf("Transport mode of the port %s does not match expected %s, got %s",
+					intf.InterfaceName, intf.TransportMode,
+					interfaces[intf.InterfaceName].TransportMode)
+			}
+		}
+	}
+}

--- a/testdata/fixtures/running_config.text
+++ b/testdata/fixtures/running_config.text
@@ -301,6 +301,23 @@ default snmp-server enable traps vrrp
 default snmp-server enable traps vrrp trap-new-master
 snmp-server vrf default
 !
+ptp priority1 128
+ptp clock-identity 00:00:00:00:00:00:00:00
+ptp priority2 128
+ptp domain 0
+ptp source ip 1.1.1.1
+ptp mode boundary
+ptp ttl 30
+ptp message-type general dscp 0 default
+ptp message-type event dscp 21 default
+ptp hold-ptp-time 28800
+no ptp forward-v1
+no ptp forward-unicast
+ptp monitor
+no ptp monitor threshold offset-from-master
+no ptp monitor threshold mean-path-delay
+no ptp monitor threshold skew
+!
 spanning-tree mode mstp
 spanning-tree hello-time 2000
 spanning-tree max-age 20
@@ -543,6 +560,9 @@ interface Ethernet1
    lacp port-priority 32768
    lldp transmit
    lldp receive
+   ptp enable
+   ptp transport ipv4
+   ptp role dynamic
    no msrp
    no mvrp
    no switchport port-security
@@ -675,6 +695,8 @@ interface Ethernet2
    lacp port-priority 32768
    lldp transmit
    lldp receive
+   ptp mode master
+   ptp transport layer2
    no msrp
    no mvrp
    no switchport port-security

--- a/testdata/fixtures/show_ptp.json
+++ b/testdata/fixtures/show_ptp.json
@@ -1,0 +1,35 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    {},
+    {
+      "ptpClockSummary": {
+        "clockIdentity": "0x01:01:01:ff:ff:01:a0:01",
+        "meanPathDelay": 230,
+        "stepsRemoved": 3,
+        "skew": 1.0000087855985595,
+        "gmClockIdentity": "0x01:01:01:ff:fe:01:a0:02",
+        "slavePort": "Ethernet49/1",
+        "numberOfMasterPorts": 1,
+        "numberOfSlavePorts": 1,
+        "currentPtpSystemTime": 1557315926,
+        "offsetFromMaster": -10,
+        "lastSyncTime": 1557315926
+      },
+      "ptpMode": "ptpBoundaryClock",
+      "ptpIntfSummaries": {
+        "Ethernet49/1": {
+          "portState": "psSlave",
+          "delayMechanism": "e2e",
+          "transportMode": "ipv4"
+        },
+        "Ethernet53/1": {
+          "portState": "psMaster",
+          "delayMechanism": "e2e",
+          "transportMode": "ipv4"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hi,
in this pull request, I want to merge the new ptp module, which allows

- fetching "show ptp" command
```go
func printPtp(showptp *module.ShowPTP) {
	fmt.Printf("\n|%-25v| : %v\n", "Ptp Mode ", showptp.PtpMode)
	fmt.Printf("|%-25v| : %v\n", "Ptp GM ", showptp.PtpClockSummary.GmClockIdentity)
	fmt.Printf("|%-25v| : %v\n", "Ptp Local Identity", showptp.PtpClockSummary.ClockIdentity)
	fmt.Printf("|%-15v%-15v%-15v%-15v\n", "Interface", "State", "Transport", "DelayMech")
	for name, port := range showptp.PtpIntfSummaries {
		fmt.Printf("|%-15v%-15v%-15v%-15v\n", name, port.PortState, port.TransportMode, port.DelayMechanism)
	}
}
...
	var showptp module.ShowPTP

	handle, _ := node.GetHandle("json")
	if err := handle.Enable(&showptp); err != nil {
		panic(err)
	}
	printPtp(&showptp)
```
Output:
```bash
|Ptp Mode                 | : ptpBoundaryClock
|Ptp GM                   | : 0x00:00:00:ff:fe:00:01:01
|Ptp Local Identity       | : 0x00:00:00:ff:ff:00:01:02
|Interface      State          Transport      DelayMech
|Ethernet49/1   psSlave        ipv4           e2e
|Ethernet53/1   psMaster       ipv4           e2e
```

- configuring system-level ptp parameters, like "mode", "ttl", "source ip"
```go
ptp := module.Ptp(node)
ptp.SetSourceIP("1.1.1.1")
ptp.SetTtl("27")
```
- enabling, disabling ptp on the interface level
```go
ptpIntEntiry := ptp.Interfaces()
ptpIntEntiry.SetEnable("Ethernet20", false)
ptpInterface := ptpIntEntiry.Get("Ethernet20")
fmt.Println(ptpInterface.GetPTPAdminStatus())
```
