### PR TITLE
Add "show queue-monitor length" command.

### DIFF
--- a/module/queue.go
+++ b/module/queue.go
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2015-2016, Arista Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+//   * Neither the name of Arista Networks nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+// IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+package module
+
+import "fmt"
+
+// ShowQueueMonitor represents "show queue-monitor length" output
+type ShowQueueMonitor struct {
+	Cmd                 string
+	ReportTime          float64  `json:"report_time"`
+	Warnings            string   `json:"warnings"`
+	BytesPerTxmpSegment uint     `json:"bytes_per_txmp_segment"`
+	GlobalHitCount      uint     `json:"global_hit_count"`
+	LanzEnabled         bool     `json:"lanz_enabled"`
+	PlatformName        string   `json:"platform_name"`
+	EntryList           []*Entry `json:"entry_list"`
+}
+
+// Entry is queueing event entry from the ShowQueueMonitor output:
+// Type       Time                    Intf(TC)           Queue         Duration      Ingress
+//                                                      Length                      Port-set
+//                                                      (bytes)       (usecs)
+//---------- ----------------------- --------------- ------------- ---------------- ------------------------------------------------
+// P          0:00:03.83243 ago       Et24/1(2)          41904         1000000       Et3/1,4/1,5/1,8/1,9/1,10/1,25/1,26/1,30/1
+type Entry struct {
+	EntryTimeUsecs              int64    `json:"entry_time_usecs"`
+	GlobalProtectionModeEnabled bool     `json:"global_protection_mode_enabled"`
+	EntryTime                   float64  `json:"entry_time"`
+	Interface                   string   `json:"interface"`
+	Duration                    uint     `json:"duration"`
+	DurationUsecs               uint32   `json:"duration_usecs"`
+	EntryType                   string   `json:"entry_type"`
+	QueueLength                 uint32   `json:"queue_length"`
+	TrafficClass                uint     `json:"traffic_class"`
+	IngressPortSet              []string `json:"ingress_port_set"`
+}
+
+func (l *ShowQueueMonitor) SetCmd(port string, limit bool, limitBy string, limitValue int) {
+	base := "show queue-monitor length"
+	if limit {
+		l.Cmd = fmt.Sprintf("%s %s limit %d %s", base, port, limitValue, limitBy)
+	} else {
+		l.Cmd = fmt.Sprintf("%s %s", base, port)
+	}
+}
+
+func (l *ShowQueueMonitor) GetCmd() string {
+	return l.Cmd
+}
+
+func (s *ShowEntity) ShowQueueMonitor(port string, limit bool, limitBy string, limitValue int) (ShowQueueMonitor, error) {
+	showqueuemonitor := ShowQueueMonitor{}
+	showqueuemonitor.SetCmd(port, limit, limitBy, limitValue)
+
+	handle, err := s.node.GetHandle("json")
+	if err != nil {
+		return showqueuemonitor, err
+	}
+
+	err = handle.AddCommand(&showqueuemonitor)
+	if err != nil {
+		return showqueuemonitor, err
+	}
+
+	err = handle.Call()
+	if err != nil {
+		return showqueuemonitor, err
+	}
+
+	handle.Close()
+	return showqueuemonitor, nil
+}

--- a/module/queue_test.go
+++ b/module/queue_test.go
@@ -1,0 +1,203 @@
+package module
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aristanetworks/goeapi"
+)
+
+func TestShowQueueMonitor_UnitTest(t *testing.T) {
+	var dummyNode *goeapi.Node
+	var dummyConnection *DummyConnection
+
+	dummyConnection = &DummyConnection{}
+
+	dummyNode = &goeapi.Node{}
+	dummyNode.SetConnection(dummyConnection)
+
+	show := Show(dummyNode)
+	showqueue, _ := show.ShowQueueMonitor("", false, "", 0)
+
+	type ShowQueueMonitor struct {
+		Cmd                 string
+		ReportTime          float64  `json:"report_time"`
+		Warnings            string   `json:"warnings"`
+		BytesPerTxmpSegment uint     `json:"bytes_per_txmp_segment"`
+		GlobalHitCount      uint     `json:"global_hit_count"`
+		LanzEnabled         bool     `json:"lanz_enabled"`
+		PlatformName        string   `json:"platform_name"`
+		EntryList           []*Entry `json:"entry_list"`
+	}
+
+	type Entry struct {
+		EntryTimeUsecs              int64    `json:"entry_time_usecs"`
+		GlobalProtectionModeEnabled bool     `json:"global_protection_mode_enabled"`
+		EntryTime                   float64  `json:"entry_time"`
+		Interface                   string   `json:"interface"`
+		Duration                    uint     `json:"duration"`
+		DurationUsecs               uint32   `json:"duration_usecs"`
+		EntryType                   string   `json:"entry_type"`
+		QueueLength                 uint32   `json:"queue_length"`
+		TrafficClass                uint     `json:"traffic_class"`
+		IngressPortSet              []string `json:"ingress_port_set"`
+	}
+
+	var scenarios = []struct {
+		GlobalHitCount uint
+		LanzEnabled    bool
+		PlatformName   string
+		EntryList      []*Entry
+	}{
+		{
+			GlobalHitCount: 0,
+			LanzEnabled:    true,
+			PlatformName:   "Sand",
+			EntryList: []*Entry{
+				{
+					EntryTimeUsecs:              1568892560445182,
+					GlobalProtectionModeEnabled: true,
+					EntryTime:                   1568892560.445182,
+					Interface:                   "Ethernet24",
+					EntryType:                   "P",
+					QueueLength:                 73520,
+					IngressPortSet: []string{
+						"Ethernet4/1",
+						"Ethernet8/1",
+						"Ethernet26/1",
+						"Ethernet30/1",
+						"Ethernet10/1",
+						"Ethernet25/1",
+						"Ethernet5/1",
+						"Ethernet9/1",
+						"Ethernet3/1",
+					},
+				},
+				{
+					EntryTimeUsecs:              1568892557441976,
+					GlobalProtectionModeEnabled: true,
+					EntryTime:                   1568892557.441976,
+					Interface:                   "Ethernet24/1",
+					EntryType:                   "P",
+					QueueLength:                 489744,
+					IngressPortSet: []string{
+						"Ethernet24/3",
+						"Ethernet13/1",
+						"Ethernet35/1",
+						"Ethernet23/1",
+						"Ethernet33/1",
+						"Ethernet19/1",
+						"Ethernet14/1",
+						"Ethernet18/1",
+						"Ethernet24/1",
+						"Ethernet34/1",
+						"Ethernet24/4",
+						"Ethernet24/2",
+					},
+				},
+				{
+					EntryTimeUsecs:              1568892549432686,
+					GlobalProtectionModeEnabled: true,
+					EntryTime:                   1568892549.432686,
+					Interface:                   "Ethernet24/1",
+					EntryType:                   "P",
+					QueueLength:                 46384,
+					IngressPortSet: []string{
+						"Ethernet4/1",
+						"Ethernet8/1",
+						"Ethernet26/1",
+						"Ethernet30/1",
+						"Ethernet10/1",
+						"Ethernet25/1",
+						"Ethernet5/1",
+						"Ethernet9/1",
+						"Ethernet3/1",
+					},
+				},
+				{
+					EntryTimeUsecs:              1568892541423988,
+					GlobalProtectionModeEnabled: true,
+					EntryTime:                   1568892541.423988,
+					Interface:                   "Ethernet24/1",
+					EntryType:                   "P",
+					QueueLength:                 247568,
+					IngressPortSet: []string{
+						"Ethernet24/3",
+						"Ethernet13/1",
+						"Ethernet35/1",
+						"Ethernet23/1",
+						"Ethernet33/1",
+						"Ethernet19/1",
+						"Ethernet14/1",
+						"Ethernet18/1",
+						"Ethernet24/1",
+						"Ethernet34/1",
+						"Ethernet24/4",
+						"Ethernet24/2",
+					},
+				},
+			},
+		},
+	}
+
+	entries := showqueue.EntryList
+
+	for _, tt := range scenarios {
+		if tt.LanzEnabled != showqueue.LanzEnabled {
+			t.Errorf("Lanz is disabled, which does not match expected %t, got %t", tt.LanzEnabled,
+				showqueue.LanzEnabled)
+		}
+		if tt.PlatformName != showqueue.PlatformName {
+			t.Errorf("Platform name doesn't match expected %s, got %s", tt.PlatformName, showqueue.PlatformName)
+		}
+		for idx, entry := range tt.EntryList {
+			if entry.EntryTime != entries[idx].EntryTime {
+				t.Errorf("Entry time does not match expected %f, got %f",
+					entry.EntryTime, entries[idx].EntryTime)
+			}
+			if entry.EntryType != entries[idx].EntryType {
+				t.Errorf("Entry type does not match expected %s, got %s",
+					entry.EntryType, entries[idx].EntryType)
+			}
+			if entry.QueueLength != entries[idx].QueueLength {
+				t.Errorf("Queue Length does not match expected %d, got %d",
+					entry.QueueLength, entries[idx].QueueLength)
+			}
+			if !reflect.DeepEqual(entry.IngressPortSet, entries[idx].IngressPortSet) {
+				t.Errorf("Ingres Port set does not match expected %v, got %v",
+					entry.IngressPortSet, entries[idx].IngressPortSet)
+			}
+		}
+	}
+
+	showqueue, _ = show.ShowQueueMonitor("Et24", true, "samples", 2)
+	entries = showqueue.EntryList
+
+	for _, tt := range scenarios {
+		if tt.LanzEnabled != showqueue.LanzEnabled {
+			t.Errorf("Lanz is disabled, which does not match expected %t, got %t", tt.LanzEnabled,
+				showqueue.LanzEnabled)
+		}
+		if tt.PlatformName != showqueue.PlatformName {
+			t.Errorf("Platform name doesn't match expected %s, got %s", tt.PlatformName, showqueue.PlatformName)
+		}
+		for idx, entry := range tt.EntryList {
+			if entry.EntryTime != entries[idx].EntryTime {
+				t.Errorf("Entry time does not match expected %f, got %f",
+					entry.EntryTime, entries[idx].EntryTime)
+			}
+			if entry.EntryType != entries[idx].EntryType {
+				t.Errorf("Entry type does not match expected %s, got %s",
+					entry.EntryType, entries[idx].EntryType)
+			}
+			if entry.QueueLength != entries[idx].QueueLength {
+				t.Errorf("Queue Length does not match expected %d, got %d",
+					entry.QueueLength, entries[idx].QueueLength)
+			}
+			if !reflect.DeepEqual(entry.IngressPortSet, entries[idx].IngressPortSet) {
+				t.Errorf("Ingres Port set does not match expected %v, got %v",
+					entry.IngressPortSet, entries[idx].IngressPortSet)
+			}
+		}
+	}
+}

--- a/testdata/fixtures/running_config.text
+++ b/testdata/fixtures/running_config.text
@@ -125,10 +125,10 @@ ip msdp timer 30
 !
 lacp system-priority 32768
 !
-no queue-monitor length
+queue-monitor length
 !
 queue-monitor length global-buffer thresholds 512 256
-no queue-monitor length mirror
+queue-monitor length mirror
 !
 queue-monitor length global-buffer
 !

--- a/testdata/fixtures/show_queue-monitor_length_.json
+++ b/testdata/fixtures/show_queue-monitor_length_.json
@@ -1,0 +1,110 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    {},
+    {
+    "reportTime": 1568892561.551359,
+    "bytesPerTxmpSegment": 512,
+    "globalHitCount": 0,
+    "lanzEnabled": true,
+    "platformName": "Sand",
+    "entryList": [
+        {
+            "entryTimeUsecs": 1568892560445182,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892560.445182,
+            "ingressPortSet": [
+                "Ethernet4/1",
+                "Ethernet8/1",
+                "Ethernet26/1",
+                "Ethernet30/1",
+                "Ethernet10/1",
+                "Ethernet25/1",
+                "Ethernet5/1",
+                "Ethernet9/1",
+                "Ethernet3/1"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 73520,
+            "trafficClass": 2
+        },
+        {
+            "entryTimeUsecs": 1568892557441976,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892557.441976,
+            "ingressPortSet": [
+                "Ethernet24/3",
+                "Ethernet13/1",
+                "Ethernet35/1",
+                "Ethernet23/1",
+                "Ethernet33/1",
+                "Ethernet19/1",
+                "Ethernet14/1",
+                "Ethernet18/1",
+                "Ethernet24/1",
+                "Ethernet34/1",
+                "Ethernet24/4",
+                "Ethernet24/2"
+            ],
+            "interface": "Ethernet24",
+            "duration": 4,
+            "durationUsecs": 4004448,
+            "entryType": "P",
+            "queueLength": 489744,
+            "trafficClass": 0
+        },
+        {
+            "entryTimeUsecs": 1568892549432686,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892549.432686,
+            "ingressPortSet": [
+                "Ethernet4/1",
+                "Ethernet8/1",
+                "Ethernet26/1",
+                "Ethernet30/1",
+                "Ethernet10/1",
+                "Ethernet25/1",
+                "Ethernet5/1",
+                "Ethernet9/1",
+                "Ethernet3/1"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 46384,
+            "trafficClass": 2
+        },
+        {
+            "entryTimeUsecs": 1568892541423988,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892541.423988,
+            "ingressPortSet": [
+                "Ethernet24/3",
+                "Ethernet13/1",
+                "Ethernet35/1",
+                "Ethernet23/1",
+                "Ethernet33/1",
+                "Ethernet19/1",
+                "Ethernet14/1",
+                "Ethernet18/1",
+                "Ethernet24/1",
+                "Ethernet34/1",
+                "Ethernet24/4",
+                "Ethernet24/2"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 247568,
+            "trafficClass": 0
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/fixtures/show_queue-monitor_length_Et24_limit_2_samples.json
+++ b/testdata/fixtures/show_queue-monitor_length_Et24_limit_2_samples.json
@@ -1,0 +1,110 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    {},
+    {
+    "reportTime": 1568892561.551359,
+    "bytesPerTxmpSegment": 512,
+    "globalHitCount": 0,
+    "lanzEnabled": true,
+    "platformName": "Sand",
+    "entryList": [
+        {
+            "entryTimeUsecs": 1568892560445182,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892560.445182,
+            "ingressPortSet": [
+                "Ethernet4/1",
+                "Ethernet8/1",
+                "Ethernet26/1",
+                "Ethernet30/1",
+                "Ethernet10/1",
+                "Ethernet25/1",
+                "Ethernet5/1",
+                "Ethernet9/1",
+                "Ethernet3/1"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 73520,
+            "trafficClass": 2
+        },
+        {
+            "entryTimeUsecs": 1568892557441976,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892557.441976,
+            "ingressPortSet": [
+                "Ethernet24/3",
+                "Ethernet13/1",
+                "Ethernet35/1",
+                "Ethernet23/1",
+                "Ethernet33/1",
+                "Ethernet19/1",
+                "Ethernet14/1",
+                "Ethernet18/1",
+                "Ethernet24/1",
+                "Ethernet34/1",
+                "Ethernet24/4",
+                "Ethernet24/2"
+            ],
+            "interface": "Ethernet24",
+            "duration": 4,
+            "durationUsecs": 4004448,
+            "entryType": "P",
+            "queueLength": 489744,
+            "trafficClass": 0
+        },
+        {
+            "entryTimeUsecs": 1568892549432686,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892549.432686,
+            "ingressPortSet": [
+                "Ethernet4/1",
+                "Ethernet8/1",
+                "Ethernet26/1",
+                "Ethernet30/1",
+                "Ethernet10/1",
+                "Ethernet25/1",
+                "Ethernet5/1",
+                "Ethernet9/1",
+                "Ethernet3/1"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 46384,
+            "trafficClass": 2
+        },
+        {
+            "entryTimeUsecs": 1568892541423988,
+            "globalProtectionModeEnabled": true,
+            "entryTime": 1568892541.423988,
+            "ingressPortSet": [
+                "Ethernet24/3",
+                "Ethernet13/1",
+                "Ethernet35/1",
+                "Ethernet23/1",
+                "Ethernet33/1",
+                "Ethernet19/1",
+                "Ethernet14/1",
+                "Ethernet18/1",
+                "Ethernet24/1",
+                "Ethernet34/1",
+                "Ethernet24/4",
+                "Ethernet24/2"
+            ],
+            "interface": "Ethernet24",
+            "duration": 1,
+            "durationUsecs": 1000000,
+            "entryType": "P",
+            "queueLength": 247568,
+            "trafficClass": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add parsing of json output of the command 
"show queue-monitor length [interface] [limit] [seconds|sample] [seconds|samples]".

If merged on the Sand platforms will be possible to do this:
```go
	showqueue := &module.ShowQueueMonitor{}
	showqueue.SetCmd("Et24/1", true, "seconds", 10)
	fmt.Println(showqueue.Cmd)

	handle, _ := node.GetHandle("json")
	if err = handle.Enable(showqueue); err != nil {
		panic(err)
	}

	fmt.Println(showqueue.ReportTime)
	fmt.Println(showqueue.GlobalHitCount)
	for _, entry := range showqueue.EntryList {
		fmt.Println(entry.Interface)
		fmt.Println(entry.EntryTime)
		fmt.Println(entry.EntryTimeUsecs)
		fmt.Println(entry.QueueLength)
		for _, port := range entry.IngressPortSet {
			fmt.Println(port)
		}
	}
```
```bash
go run arista_command.go                                                                                                                                                           40232❮ ◀12:16:39
show queue-monitor length Et24/1 limit 10 seconds
1.569233803510707e+09
0
Ethernet24/1
1.569233799625076e+09
1569233799625076
144336
Ethernet24/3
Ethernet13/1
Ethernet35/1
Ethernet23/1
Ethernet33/1
Ethernet19/1
Ethernet14/1
Ethernet18/1
Ethernet24/1
Ethernet34/1
Ethernet24/4
Ethernet24/2
```