### PR TITLE
Force mapstructure decoder tag to the json tag

### DIFF
--- a/eapi.go
+++ b/eapi.go
@@ -251,6 +251,7 @@ func (handle *EapiReqHandle) Call() error {
 	commands := handle.getAllCommands()
 
 	jsonrsp, err := handle.node.conn.Execute(commands, handle.encoding)
+        
 	if err != nil {
 		return err
 	}
@@ -315,7 +316,13 @@ func (handle *EapiReqHandle) parseResponse(resp *JSONRPCResponse) error {
 		if cmd.EapiCommand == nil {
 			continue
 		}
-		err := mapstructure.Decode(result, cmd.EapiCommand)
+
+                d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{ TagName: "json", Result: cmd.EapiCommand })
+                if err != nil {
+			return err
+                } 
+
+                err = d.Decode(result)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since mapstructure is only used in this part of the code, I think it should be save enough to force mapstructure to use the json tag for unmarshalling instead of the default `mapstructure` tag.