### PR TITLE
Add support for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ func main() {
 
         sv := &MyShowVlan{}
 
-        handle, _ := node.GetHandle("json")
+        handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
         handle.AddCommand(sv)
         if err := handle.Call(); err != nil {
                 panic(err)
@@ -258,7 +258,7 @@ func main() {
 Also, if several commands/responses have been defined, goeapi supports command stacking to batch issue all at once:
 ```go
     ...
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
 	handle.AddCommand(showVersion)
 	handle.AddCommand(showVlan)
 	handle.AddCommand(showHostname)

--- a/client.go
+++ b/client.go
@@ -195,7 +195,7 @@ func (n *Node) GetConfig(config, params, encoding string) (map[string]interface{
 	}
 	commands := []string{strings.TrimSpace("show " + config + " " + params)}
 
-	result, err := n.runCommands(commands, encoding)
+	result, err := n.runCommands(commands, encoding, false)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (n *Node) GetSection(regex string, config string) (string, error) {
 // to put the session into config mode. Returns error if issues arise.
 func (n *Node) ConfigWithErr(commands ...string) error {
 	commands = append([]string{"configure terminal"}, commands...)
-	_, err := n.runCommands(commands, "json")
+	_, err := n.runCommands(commands, "json", false)
 	if n.autoRefresh {
 		n.Refresh()
 	}
@@ -302,7 +302,7 @@ func (n *Node) Enable(commands []string) ([]map[string]string, error) {
 	}
 
 	results := make([]map[string]string, len(commands))
-	jsonRsp, err := n.runCommands(commands, "text")
+	jsonRsp, err := n.runCommands(commands, "text", false)
 	if err != nil {
 		return results, err
 	}
@@ -330,7 +330,7 @@ func (n *Node) Enable(commands []string) ([]map[string]string, error) {
 //  This method will return the raw response from the connection
 //  which is a JSONRPCResponse object or error on failure.
 func (n *Node) runCommands(commands []string,
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	var cmds []interface{}
 
 	// Check to see if enablePasswd has been set. In the case where
@@ -347,7 +347,7 @@ func (n *Node) runCommands(commands []string,
 		cmds = cmdsToInterface(commands)
 	}
 
-	result, err := n.conn.Execute(cmds, encoding)
+	result, err := n.conn.Execute(cmds, encoding, streaming)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -347,7 +347,7 @@ func (n *Node) runCommands(commands []string,
 		cmds = cmdsToInterface(commands)
 	}
 
-	result, err := n.conn.Execute(cmds, encoding, streaming)
+	result, err := n.conn.Execute(cmds, encoding)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -171,8 +171,8 @@ func GetHandle(n *Node, params Parameters) (*EapiReqHandle, error) {
 //
 // Returns:
 //  Pointer to an EapiReqHandle or error on failure
-func (n *Node) GetHandle(encoding string) (*EapiReqHandle, error) {
-	return GetHandle(n, Parameters{Format: encoding})
+func (n *Node) GetHandle(p Parameters) (*EapiReqHandle, error) {
+	return GetHandle(n, p)
 }
 
 // GetConfig retrieves the config from the node.

--- a/client_test.go
+++ b/client_test.go
@@ -387,7 +387,7 @@ func TestClientEnableSingleResult_SystemTest(t *testing.T) {
 		cmds := []string{
 			"show version",
 		}
-		ret, _ := dut.runCommands(cmds, "json")
+		ret, _ := dut.runCommands(cmds, "json", false)
 		if len(ret.Result) != 1 {
 			t.Fatalf("sizes do not match Result[%d] != 1\n", len(ret.Result))
 		}
@@ -399,7 +399,7 @@ func TestClientEnableMultipleResult_SystemTest(t *testing.T) {
 		for i := 0; i < RandomInt(10, 200); i++ {
 			cmds = append(cmds, "show version")
 		}
-		ret, _ := dut.runCommands(cmds, "json")
+		ret, _ := dut.runCommands(cmds, "json", false)
 		if len(ret.Result) != len(cmds) {
 			t.Fatalf("sizes do not match Result[%d] != cmds[%d]\n", len(ret.Result), len(cmds))
 		}
@@ -411,7 +411,7 @@ func TestClientEnableMultiRequests_SystemTest(t *testing.T) {
 			"show version",
 		}
 		for i := 0; i < RandomInt(10, 200); i++ {
-			ret, _ := dut.runCommands(cmds, "json")
+			ret, _ := dut.runCommands(cmds, "json", false)
 			if len(ret.Result) != 1 {
 				t.Fatalf("sizes do not match Result[%d] != 1\n", len(ret.Result))
 			}
@@ -428,7 +428,7 @@ func TestClientConfigSingle_SystemTest(t *testing.T) {
 			t.Fatalf("Config failure\n")
 		}
 		name := strings.Split(cmds[len(cmds)-1], " ")[1]
-		ret, _ := dut.runCommands([]string{"show hostname"}, "json")
+		ret, _ := dut.runCommands([]string{"show hostname"}, "json", false)
 		if ret.Result[0]["hostname"] != name {
 			t.Fatalf("Expecting %s got %s\n", name, ret.Result[0]["hostname"])
 		}
@@ -446,7 +446,7 @@ func TestClientConfigMultiple_SystemTest(t *testing.T) {
 		}
 		// just check last
 		name := strings.Split(cmds[len(cmds)-1], " ")[1]
-		ret, _ := dut.runCommands([]string{"show hostname"}, "json")
+		ret, _ := dut.runCommands([]string{"show hostname"}, "json", false)
 		if ret.Result[0]["hostname"] != name {
 			t.Fatalf("Expecting %s got %s\n", name, ret.Result[0]["hostname"])
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -620,30 +620,30 @@ func TestClientNodeEnableValid_SystemTest(t *testing.T) {
 func TestClientHandleEncoding_UnitTest(t *testing.T) {
 	node := &Node{}
 
-	if _, err := node.GetHandle("json"); err != nil {
+	if _, err := node.GetHandle(Parameters{Format: "json"}); err != nil {
 		t.Fatal("GetHandle json")
 	}
-	if _, err := node.GetHandle("text"); err != nil {
+	if _, err := node.GetHandle(Parameters{Format: "text"}); err != nil {
 		t.Fatal("GetHandle text")
 	}
-	if _, err := node.GetHandle("crap"); err == nil {
+	if _, err := node.GetHandle(Parameters{Format: "crap"}); err == nil {
 		t.Fatal("GetHandle crap")
 	}
-	if _, err := node.GetHandle("JsOn"); err != nil {
+	if _, err := node.GetHandle(Parameters{Format: "JsOn"}); err != nil {
 		t.Fatal("GetHandle JsOn")
 	}
 }
 
 func TestClientHandleInvalid_UnitTest(t *testing.T) {
 	var node *Node
-	if _, err := node.GetHandle("json"); err == nil {
+	if _, err := node.GetHandle(Parameters{Format: "json"}); err == nil {
 		t.Fatal("GetHandle invalid failed")
 	}
 }
 
 func TestClientHandleClose_UnitTest(t *testing.T) {
 	node := &Node{}
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(Parameters{Format: "json"})
 	handle.Close()
 
 	if err := handle.Call(); err == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -387,7 +387,7 @@ func TestClientEnableSingleResult_SystemTest(t *testing.T) {
 		cmds := []string{
 			"show version",
 		}
-		ret, _ := dut.runCommands(cmds, "json", false)
+		ret, _ := dut.runCommands(cmds, Parameters{Format: "json"})
 		if len(ret.Result) != 1 {
 			t.Fatalf("sizes do not match Result[%d] != 1\n", len(ret.Result))
 		}
@@ -399,7 +399,7 @@ func TestClientEnableMultipleResult_SystemTest(t *testing.T) {
 		for i := 0; i < RandomInt(10, 200); i++ {
 			cmds = append(cmds, "show version")
 		}
-		ret, _ := dut.runCommands(cmds, "json", false)
+		ret, _ := dut.runCommands(cmds, Parameters{Format: "json"})
 		if len(ret.Result) != len(cmds) {
 			t.Fatalf("sizes do not match Result[%d] != cmds[%d]\n", len(ret.Result), len(cmds))
 		}
@@ -411,7 +411,7 @@ func TestClientEnableMultiRequests_SystemTest(t *testing.T) {
 			"show version",
 		}
 		for i := 0; i < RandomInt(10, 200); i++ {
-			ret, _ := dut.runCommands(cmds, "json", false)
+			ret, _ := dut.runCommands(cmds, Parameters{Format: "json"})
 			if len(ret.Result) != 1 {
 				t.Fatalf("sizes do not match Result[%d] != 1\n", len(ret.Result))
 			}
@@ -428,7 +428,7 @@ func TestClientConfigSingle_SystemTest(t *testing.T) {
 			t.Fatalf("Config failure\n")
 		}
 		name := strings.Split(cmds[len(cmds)-1], " ")[1]
-		ret, _ := dut.runCommands([]string{"show hostname"}, "json", false)
+		ret, _ := dut.runCommands([]string{"show hostname"}, Parameters{Format: "json"})
 		if ret.Result[0]["hostname"] != name {
 			t.Fatalf("Expecting %s got %s\n", name, ret.Result[0]["hostname"])
 		}
@@ -446,7 +446,7 @@ func TestClientConfigMultiple_SystemTest(t *testing.T) {
 		}
 		// just check last
 		name := strings.Split(cmds[len(cmds)-1], " ")[1]
-		ret, _ := dut.runCommands([]string{"show hostname"}, "json", false)
+		ret, _ := dut.runCommands([]string{"show hostname"}, Parameters{Format: "json"})
 		if ret.Result[0]["hostname"] != name {
 			t.Fatalf("Expecting %s got %s\n", name, ret.Result[0]["hostname"])
 		}

--- a/eapi.go
+++ b/eapi.go
@@ -46,56 +46,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Format for eapi response
-type Format int
-
-const (
-	// Text formatting for eapi responses
-	Text Format = 0
-
-	// JSON formatting for eapi responses
-	JSON Format = 1
-)
-
-// FormatFromString converts a string to Format constant
-func FormatFromString(s string) Format {
-	var f Format
-
-	switch s {
-	case "text":
-		f = Text
-	case "json":
-		f = JSON
-	}
-
-	return f
-}
-
-// String
-func (f Format) String() string {
-	return [...]string{"text", "json"}[f]
-}
-
-// MarshalJSON renders a Format to a json string
-func (f Format) MarshalJSON() ([]byte, error) {
-	buffer := bytes.NewBufferString(`"`)
-	buffer.WriteString(f.String())
-	buffer.WriteString(`"`)
-	return buffer.Bytes(), nil
-}
-
-// UnmarshalJSON decodes a json string to a Format
-func (f Format) UnmarshalJSON(b []byte) error {
-	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
-		return err
-	}
-
-	f = FormatFromString(j)
-	return nil
-}
-
 // Request ...
 type Request struct {
 	Jsonrpc   string     `json:"jsonrpc"`

--- a/eapi.go
+++ b/eapi.go
@@ -46,6 +46,56 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// Format for eapi response
+type Format int
+
+const (
+	// Text formatting for eapi responses
+	Text Format = 0
+
+	// JSON formatting for eapi responses
+	JSON Format = 1
+)
+
+// FormatFromString converts a string to Format constant
+func FormatFromString(s string) Format {
+	var f Format
+
+	switch s {
+	case "text":
+		f = Text
+	case "json":
+		f = JSON
+	}
+
+	return f
+}
+
+// String
+func (f Format) String() string {
+	return [...]string{"text", "json"}[f]
+}
+
+// MarshalJSON renders a Format to a json string
+func (f Format) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(f.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON decodes a json string to a Format
+func (f Format) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+
+	f = FormatFromString(j)
+	return nil
+}
+
 // Request ...
 type Request struct {
 	Jsonrpc   string     `json:"jsonrpc"`

--- a/eapi.go
+++ b/eapi.go
@@ -238,6 +238,7 @@ func (handle *EapiReqHandle) Call() error {
 	}
 
 	var cmd interface{}
+
 	if handle.node.enablePasswd != "" {
 		cmd = map[string]string{
 			"cmd":   "enable",
@@ -252,7 +253,13 @@ func (handle *EapiReqHandle) Call() error {
 
 	commands := handle.getAllCommands()
 
-	jsonrsp, err := handle.node.conn.Execute(commands, handle.encoding, handle.streaming)
+	var err error
+	var jsonrsp *JSONRPCResponse
+	if handle.streaming == false {
+		jsonrsp, err = handle.node.conn.Execute(commands, handle.encoding)
+	} else {
+		jsonrsp, err = handle.node.conn.Stream(commands, handle.encoding)
+	}
 
 	if err != nil {
 		return err

--- a/eapi.go
+++ b/eapi.go
@@ -340,17 +340,6 @@ func (handle *EapiReqHandle) parseResponse(resp *JSONRPCResponse) error {
 	return err
 }
 
-// SetParams sets eapi parameters
-func (handle *EapiReqHandle) SetParams(p Parameters) {
-
-	// keep format from GetHandle
-	if p.Format == "" {
-		p.Format = handle.params.Format
-	}
-
-	handle.params = p
-}
-
 // decodeEapiResponse [private] Used to decode JSON Response into
 // structure format defined by type JSONRPCResponse
 func decodeEapiResponse(resp *http.Response) (*JSONRPCResponse, error) {

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -32,7 +32,6 @@
 package goeapi
 
 import (
-	"encoding/json"
 	"regexp"
 	"testing"
 )
@@ -374,11 +373,10 @@ func TestEapiRespHandlerEnableAddError_UnitTest(t *testing.T) {
 	h = nil
 }
 
-func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
+func TestEapiRespHandlerSetParams_UnitTest(t *testing.T) {
 	show := new(ShowRunning)
 	h, _ := dummyNode.GetHandle("text")
-	h.SetStreaming(true)
-
+	h.SetParams(Parameters{Format: "text", Streaming: true})
 	if err := h.Enable(show); err != nil {
 		t.Fatal(err)
 	}
@@ -386,15 +384,15 @@ func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
 	h = nil
 }
 
-func TestDebugJSON_UnitTest(t *testing.T) {
-	p := Parameters{1, cmdsToInterface([]string{"show version", "show interface"}), "json"}
-	req := Request{"2.0", "runCmds", false, p, "255"}
-	data, err := json.Marshal(req)
-	if err != nil {
-		t.Fatal("Should return nil")
-	}
-	debugJSON(data)
-}
+// func TestDebugJSON_UnitTest(t *testing.T) {
+// 	p := Parameters{1, cmdsToInterface([]string{"show version", "show interface"}), "json"}
+// 	req := Request{"2.0", "runCmds", false, p, "255"}
+// 	data, err := json.Marshal(req)
+// 	if err != nil {
+// 		t.Fatal("Should return nil")
+// 	}
+// 	debugJSON(data)
+// }
 
 func TestEapiCall_SystemTest(t *testing.T) {
 	showdummy := new(MyShow)

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -73,7 +73,7 @@ func (s *MyShow) GetCmd() string {
 
 func TestEapiGetHandleNodeInvalid_UnitTest(t *testing.T) {
 	var node *Node
-	h, err := node.GetHandle("json")
+	h, err := node.GetHandle(Parameters{Format: "json"})
 	if err == nil {
 		t.Fatal("GetHandle invalid failed")
 	}
@@ -86,7 +86,7 @@ func TestEapiGetHandleNodeInvalid_UnitTest(t *testing.T) {
 func TestEapiRespHandlerInvalidAddCommandStr_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	h = nil
 	err := h.AddCommandStr("", showdummy)
 	if err == nil {
@@ -101,7 +101,7 @@ func TestEapiRespHandlerInvalidAddCommandStr_UnitTest(t *testing.T) {
 func TestEapiRespHandlerAddCommandStrNull_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 
 	err := h.AddCommandStr("", showdummy)
 	if err == nil {
@@ -112,7 +112,7 @@ func TestEapiRespHandlerAddCommandStrNull_UnitTest(t *testing.T) {
 func TestEapiRespHandlerInvalidAddCommand_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	h = nil
 	err := AddCommand(h, showdummy)
 	if err == nil {
@@ -123,7 +123,7 @@ func TestEapiRespHandlerInvalidAddCommand_UnitTest(t *testing.T) {
 func TestEapiRespHandlerGetAllCommands_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 
 	tests := [...]string{
 		"show version",
@@ -150,7 +150,7 @@ func TestEapiRespHandlerGetAllCommands_UnitTest(t *testing.T) {
 func TestEapiRespHandlerAddCommand_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 
 	tests := [...]struct {
 		in   int
@@ -177,7 +177,7 @@ func TestEapiRespHandlerAddCommand_UnitTest(t *testing.T) {
 func TestEapiRespHandlerGetAllCommandsChecks_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 
 	for i := 0; i < 10; i++ {
 		h.AddCommand(showdummy)
@@ -206,7 +206,7 @@ func TestEapiRespHandlerGetAllCommandsChecks_UnitTest(t *testing.T) {
 func TestEapiRespHandlerClearCommands_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 
 	tests := [...]struct {
 		in   int
@@ -260,7 +260,7 @@ func TestEapiRespHandlerCloseClearCommands_UnitTest(t *testing.T) {
 		{120, 64},
 	}
 	for _, tt := range tests {
-		h, _ := node.GetHandle("json")
+		h, _ := node.GetHandle(Parameters{Format: "json"})
 		for i := 0; i < tt.in; i++ {
 			h.AddCommand(showdummy)
 		}
@@ -278,7 +278,7 @@ func TestEapiRespHandlerCloseClearCommands_UnitTest(t *testing.T) {
 
 func TestEapiRespHandlerCallHandleNil_UnitTest(t *testing.T) {
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	h = nil
 	if err := h.Call(); err == nil {
 		t.Fatal("Should return error on nil handle Call()")
@@ -287,7 +287,7 @@ func TestEapiRespHandlerCallHandleNil_UnitTest(t *testing.T) {
 
 func TestEapiRespHandlerCallNodeNil_UnitTest(t *testing.T) {
 	node := &Node{}
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	h.Close()
 	if err := h.Call(); err == nil {
 		t.Fatal("Should return error on nil node Call()")
@@ -296,7 +296,7 @@ func TestEapiRespHandlerCallNodeNil_UnitTest(t *testing.T) {
 
 func TestEapiRespHandlerCallEnableInvalidAdd_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
-	h, _ := dummyNode.GetHandle("json")
+	h, _ := dummyNode.GetHandle(Parameters{Format: "json"})
 	for i := 0; i < 5; i++ {
 		h.AddCommandStr("", showdummy)
 	}
@@ -310,7 +310,7 @@ func TestEapiRespHandlerCallEnableInvalidAdd_UnitTest(t *testing.T) {
 func TestEapiRespHandlerCallEnablePasswd_UnitTest(t *testing.T) {
 	showdummy := new(MyShow)
 	dummyNode.EnableAuthentication("root")
-	h, _ := dummyNode.GetHandle("json")
+	h, _ := dummyNode.GetHandle(Parameters{Format: "json"})
 	for i := 0; i < 5; i++ {
 		h.AddCommand(showdummy)
 	}
@@ -324,7 +324,7 @@ func TestEapiRespHandlerCallEnablePasswd_UnitTest(t *testing.T) {
 func TestEapiRespHandlerNilHandleClose_UnitTest(t *testing.T) {
 	node := &Node{}
 
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	h = nil
 	if err := h.Close(); err == nil {
 		t.Fatal("Should return error on nil handle close")
@@ -334,7 +334,7 @@ func TestEapiRespHandlerNilHandleClose_UnitTest(t *testing.T) {
 func TestEapiRespHandlerGetNode_UnitTest(t *testing.T) {
 	node := &Node{}
 
-	h, _ := node.GetHandle("json")
+	h, _ := node.GetHandle(Parameters{Format: "json"})
 	n, err := h.getNode()
 	if n != node {
 		t.Fatal("Should be same")
@@ -349,7 +349,7 @@ func TestEapiRespHandlerGetNode_UnitTest(t *testing.T) {
 func TestEapiRespHandlerEnable_UnitTest(t *testing.T) {
 	show := new(ShowRunning)
 	dummyNode.EnableAuthentication("")
-	h, _ := dummyNode.GetHandle("text")
+	h, _ := dummyNode.GetHandle(Parameters{Format: "text"})
 	if err := h.Enable(show); err != nil {
 		t.Fatal("error on Enable()")
 	}
@@ -362,7 +362,7 @@ func TestEapiRespHandlerEnable_UnitTest(t *testing.T) {
 
 func TestEapiRespHandlerEnableAddError_UnitTest(t *testing.T) {
 	show := new(ShowRunning)
-	h, _ := dummyNode.GetHandle("text")
+	h, _ := dummyNode.GetHandle(Parameters{Format: "text"})
 	for i := 0; i < maxCmdBuflen+1; i++ {
 		h.AddCommand(show)
 	}
@@ -373,10 +373,9 @@ func TestEapiRespHandlerEnableAddError_UnitTest(t *testing.T) {
 	h = nil
 }
 
-func TestEapiRespHandlerSetParams_UnitTest(t *testing.T) {
+func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
 	show := new(ShowRunning)
-	h, _ := dummyNode.GetHandle("text")
-	h.SetParams(Parameters{Format: "text", Streaming: true})
+	h, _ := dummyNode.GetHandle(Parameters{Format: "text", Streaming: true})
 	if err := h.Enable(show); err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +403,7 @@ func TestEapiCall_SystemTest(t *testing.T) {
 		"show version",
 	}
 	for _, dut := range duts {
-		h, err := dut.GetHandle("json")
+		h, err := dut.GetHandle(Parameters{Format: "json"})
 		if err != nil {
 			t.Fatalf("GetHandle() failed: Error[%s]", err)
 		}
@@ -423,7 +422,7 @@ func TestEapiEnable_SystemTest(t *testing.T) {
 	showdummy := new(MyShow)
 	re := regexp.MustCompile(`^([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2})$`)
 	for _, dut := range duts {
-		h, err := dut.GetHandle("json")
+		h, err := dut.GetHandle(Parameters{Format: "json"})
 		if err != nil {
 			t.Fatalf("GetHandle() failed: Error[%s]", err)
 		}

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -380,7 +380,7 @@ func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
 	h.SetStreaming(true)
 
 	if err := h.Enable(show); err != nil {
-		t.Fatal("Should return nil")
+		t.Fatal(err)
 	}
 	h.Close()
 	h = nil

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -374,9 +374,21 @@ func TestEapiRespHandlerEnableAddError_UnitTest(t *testing.T) {
 	h = nil
 }
 
+func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
+	show := new(ShowRunning)
+	h, _ := dummyNode.GetHandle("text")
+	h.SetStreaming(true)
+
+	if err := h.Enable(show); err == nil {
+		t.Fatal("Should return error on adding to full command list")
+	}
+	h.Close()
+	h = nil
+}
+
 func TestDebugJSON_UnitTest(t *testing.T) {
 	p := Parameters{1, cmdsToInterface([]string{"show version", "show interface"}), "json"}
-	req := Request{"2.0", "runCmds", p, "255"}
+	req := Request{"2.0", "runCmds", false, p, "255"}
 	data, err := json.Marshal(req)
 	if err != nil {
 		t.Fatal("Should return nil")

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -32,6 +32,7 @@
 package goeapi
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 )
@@ -383,15 +384,39 @@ func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
 	h = nil
 }
 
-// func TestDebugJSON_UnitTest(t *testing.T) {
-// 	p := Parameters{1, cmdsToInterface([]string{"show version", "show interface"}), "json"}
-// 	req := Request{"2.0", "runCmds", false, p, "255"}
-// 	data, err := json.Marshal(req)
-// 	if err != nil {
-// 		t.Fatal("Should return nil")
-// 	}
-// 	debugJSON(data)
-// }
+func TestDebugJSON_UnitTest(t *testing.T) {
+	//p := Parameters{1, cmdsToInterface([]string{"show version", "show interface"}), "json"}
+	p := struct {
+		Version            int           `json:"version"`
+		Cmds               []interface{} `json:"cmds"`
+		Format             string        `json:"format"`
+		Timestamps         bool          `json:"timestamps,omitempty"`
+		AutoComplete       bool          `json:"autoComplete,omitempty"`
+		ExpandAliases      bool          `json:"expandAliases,omitempty"`
+		IncludeErrorDetail bool          `json:"includeErrorDetail,omitempty"`
+		Streaming          bool          `json:"streaming,omitempty"`
+	}{
+		Version: 1,
+		Cmds:    cmdsToInterface([]string{"show version", "show interface"}),
+		Format:  "json",
+	}
+	req := struct {
+		Method  string      `json:"method"`
+		Params  interface{} `json:"params,omitempty"`
+		ID      string      `json:"id,omitempty"`
+		JSONRPC string      `json:"jsonrpc"`
+	}{
+		JSONRPC: "2.0",
+		Method:  "runCmds",
+		Params:  p,
+		ID:      "1001",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal("Should return nil")
+	}
+	debugJSON(data)
+}
 
 func TestEapiCall_SystemTest(t *testing.T) {
 	showdummy := new(MyShow)

--- a/eapi_test.go
+++ b/eapi_test.go
@@ -379,8 +379,8 @@ func TestEapiRespHandlerSetStreaming_UnitTest(t *testing.T) {
 	h, _ := dummyNode.GetHandle("text")
 	h.SetStreaming(true)
 
-	if err := h.Enable(show); err == nil {
-		t.Fatal("Should return error on adding to full command list")
+	if err := h.Enable(show); err != nil {
+		t.Fatal("Should return nil")
 	}
 	h.Close()
 	h = nil

--- a/eapilib.go
+++ b/eapilib.go
@@ -49,7 +49,7 @@ import (
 // EapiConnectionEntity is an interface representing the ability to execute a
 // single json transaction, obtaining the Response for a given Request.
 type EapiConnectionEntity interface {
-	Execute(commands []interface{}, encoding string) (*JSONRPCResponse, error)
+	Execute(commands []interface{}, encoding string, streaming bool) (*JSONRPCResponse, error)
 	SetTimeout(to uint32)
 	Error() error
 }
@@ -79,7 +79,7 @@ type EapiConnection struct {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *EapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
@@ -160,10 +160,10 @@ func (conn *EapiConnection) SetTimeout(timeOut uint32) {
 // entries both can be used. Returns []byte of the built JSON request.
 // Successful call returns err == nil.
 func buildJSONRequest(commands []interface{},
-	encoding string, reqid string) ([]byte, error) {
+	encoding string, streaming bool, reqid string) ([]byte, error) {
 	p := Parameters{1, commands, encoding}
 
-	req := Request{"2.0", "runCmds", p, reqid}
+	req := Request{"2.0", "runCmds", streaming, p, reqid}
 	data, err := json.Marshal(req)
 	//debugJSON(data)
 	return data, err
@@ -266,12 +266,12 @@ func (conn *SocketEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *SocketEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, streaming, strconv.Itoa(os.Getpid()))
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -349,12 +349,12 @@ func (conn *HTTPLocalEapiConnection) send(data []byte) (*JSONRPCResponse, error)
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPLocalEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, streaming, strconv.Itoa(os.Getpid()))
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -453,12 +453,12 @@ func (conn *HTTPEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, streaming, strconv.Itoa(os.Getpid()))
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -569,12 +569,12 @@ func (conn *HTTPSEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPSEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, streaming, strconv.Itoa(os.Getpid()))
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err

--- a/eapilib.go
+++ b/eapilib.go
@@ -175,12 +175,11 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 	}{
 		Version: 1,
 		Cmds:    commands,
+		Format:  p.Format,
 	}
 
-	if p.Format == "" {
+	if params.Format == "" {
 		params.Format = "text"
-	} else {
-		params.Format = p.Format
 	}
 
 	//

--- a/eapilib.go
+++ b/eapilib.go
@@ -171,7 +171,7 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 		AutoComplete       bool          `json:"autoComplete,omitempty"`
 		ExpandAliases      bool          `json:"expandAliases,omitempty"`
 		IncludeErrorDetail bool          `json:"includeErrorDetail,omitempty"`
-		Streaming          bool          `json:"streaming,omitempty"`
+		//Streaming          bool          `json:"streaming,omitempty"`
 	}{
 		Version: 1,
 		Cmds:    commands,
@@ -183,6 +183,9 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 		params.Format = p.Format
 	}
 
+	//
+	// Omit optional fields if not set
+	//
 	if p.Timestamps == true {
 		params.Timestamps = p.Timestamps
 	}
@@ -199,9 +202,9 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 		params.IncludeErrorDetail = p.IncludeErrorDetail
 	}
 
-	if p.Streaming == true {
-		params.Streaming = p.Streaming
-	}
+	// if p.Streaming == true {
+	// 	params.Streaming = p.Streaming
+	// }
 
 	request := struct {
 		Method    string      `json:"method"`

--- a/eapilib.go
+++ b/eapilib.go
@@ -183,7 +183,7 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 	}
 
 	//
-	// Omit optional fields if not set
+	// Only set optional parameters if set
 	//
 	if p.Timestamps == true {
 		params.Timestamps = p.Timestamps

--- a/eapilib.go
+++ b/eapilib.go
@@ -52,7 +52,6 @@ type EapiConnectionEntity interface {
 	Execute(commands []interface{}, params Parameters) (*JSONRPCResponse, error)
 	SetTimeout(to uint32)
 	Error() error
-	send(data []byte) (*JSONRPCResponse, error)
 }
 
 // EapiConnection represents the base object for implementing an EapiConnection
@@ -68,13 +67,6 @@ type EapiConnection struct {
 	timeOut   uint32
 }
 
-func (conn *EapiConnection) send(data []byte) (*JSONRPCResponse, error) {
-	if conn == nil {
-		return &JSONRPCResponse{}, fmt.Errorf("No connection")
-	}
-	return &JSONRPCResponse{}, fmt.Errorf("Not Currently Implemented")
-}
-
 // Execute the list of commands on the destination node. In the case of
 // EapiConnection, this serves as a base model and is not fully implemented.
 //
@@ -87,17 +79,11 @@ func (conn *EapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *EapiConnection) Execute(commands []interface{},
-	params Parameters) (*JSONRPCResponse, error) {
+	encoding string) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
-	conn.ClearError()
-	data, err := buildJSONRequest(commands, params)
-	if err != nil {
-		conn.SetError(err)
-		return &JSONRPCResponse{}, err
-	}
-	return conn.send(data)
+	return &JSONRPCResponse{}, fmt.Errorf("Not Currently Implemented")
 }
 
 // Authentication Configures the user authentication for eAPI. This method
@@ -193,6 +179,8 @@ func buildJSONRequest(commands []interface{}, p Parameters) ([]byte, error) {
 
 	if p.Format == "" {
 		params.Format = "text"
+	} else {
+		params.Format = p.Format
 	}
 
 	if p.Timestamps == true {
@@ -314,6 +302,36 @@ func (conn *SocketEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 	return jsonRsp, nil
 }
 
+// Execute the list of commands on the destination node
+//
+// This method takes a list of commands and sends them to the
+// destination node, returning the results. It is assumed that the
+// list of commands (type []interface{}) has been properly built and
+// enable mode passwd is set if needed. On success, a reference
+// to JSONRPCResponse is returned...otherwise err is set.
+//
+// Args:
+//  commands ([]interface): list of commands to execute on remote node
+//  encoding (string): The encoding to send along with the request
+//                      message to the destination node.  Valid values include
+//                      'json' or 'text'.  This argument will influence the
+//                      response encoding
+// Returns:
+//  pointer to JSONRPCResponse or error on failure
+func (conn *SocketEapiConnection) Execute(commands []interface{},
+	params Parameters) (*JSONRPCResponse, error) {
+	if conn == nil {
+		return &JSONRPCResponse{}, fmt.Errorf("No connection")
+	}
+	conn.ClearError()
+	data, err := buildJSONRequest(commands, params)
+	if err != nil {
+		conn.SetError(err)
+		return &JSONRPCResponse{}, err
+	}
+	return conn.send(data)
+}
+
 // HTTPLocalEapiConnection is an EapiConnection suited for local HTTP connection
 type HTTPLocalEapiConnection struct {
 	EapiConnection
@@ -365,6 +383,36 @@ func (conn *HTTPLocalEapiConnection) send(data []byte) (*JSONRPCResponse, error)
 		return &JSONRPCResponse{}, fmt.Errorf("No Connection")
 	}
 	return &JSONRPCResponse{}, fmt.Errorf("Not Currently Implemented")
+}
+
+// Execute the list of commands
+//
+// This method takes a list of commands and sends them to the
+// destination node, returning the results. It is assumed that the
+// list of commands (type []interface{}) has been properly built and
+// enable mode passwd is set if needed. On success, a reference
+// to JSONRPCResponse is returned...otherwise err is set.
+//
+// Args:
+//  commands ([]interface): list of commands to execute on remote node
+//  encoding (string): The encoding to send along with the request
+//                      message to the destination node.  Valid values include
+//                      'json' or 'text'.  This argument will influence the
+//                      response encoding
+// Returns:
+//  pointer to JSONRPCResponse or error on failure
+func (conn *HTTPLocalEapiConnection) Execute(commands []interface{},
+	params Parameters) (*JSONRPCResponse, error) {
+	if conn == nil {
+		return &JSONRPCResponse{}, fmt.Errorf("No connection")
+	}
+	conn.ClearError()
+	data, err := buildJSONRequest(commands, params)
+	if err != nil {
+		conn.SetError(err)
+		return &JSONRPCResponse{}, err
+	}
+	return conn.send(data)
 }
 
 // HTTPEapiConnection is an EapiConnection suited for HTTP connection
@@ -439,6 +487,36 @@ func (conn *HTTPEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 		return jsonRsp, err
 	}
 	return jsonRsp, nil
+}
+
+// Execute the list of commands on the destination node
+//
+// This method takes a list of commands and sends them to the
+// destination node, returning the results. It is assumed that the
+// list of commands (type []interface{}) has been properly built and
+// enable mode passwd is set if needed. On success, a reference
+// to JSONRPCResponse is returned...otherwise err is set.
+//
+// Args:
+//  commands ([]interface): list of commands to execute on remote node
+//  encoding (string): The encoding to send along with the request
+//                      message to the destination node.  Valid values include
+//                      'json' or 'text'.  This argument will influence the
+//                      response encoding
+// Returns:
+//  pointer to JSONRPCResponse or error on failure
+func (conn *HTTPEapiConnection) Execute(commands []interface{},
+	params Parameters) (*JSONRPCResponse, error) {
+	if conn == nil {
+		return &JSONRPCResponse{}, fmt.Errorf("No connection")
+	}
+	conn.ClearError()
+	data, err := buildJSONRequest(commands, params)
+	if err != nil {
+		conn.SetError(err)
+		return &JSONRPCResponse{}, err
+	}
+	return conn.send(data)
 }
 
 // HTTPSEapiConnection is an EapiConnection suited for HTTP connection
@@ -525,6 +603,36 @@ func (conn *HTTPSEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 		return jsonRsp, err
 	}
 	return jsonRsp, nil
+}
+
+// Execute the list of commands on the destination node
+//
+// This method takes a list of commands and sends them to the
+// destination node, returning the results. It is assumed that the
+// list of commands (type []interface{}) has been properly built and
+// enable mode passwd is set if needed. On success, a reference
+// to JSONRPCResponse is returned...otherwise err is set.
+//
+// Args:
+//  commands ([]interface): list of commands to execute on remote node
+//  encoding (string): The encoding to send along with the request
+//                      message to the destination node.  Valid values include
+//                      'json' or 'text'.  This argument will influence the
+//                      response encoding
+// Returns:
+//  pointer to JSONRPCResponse or error on failure
+func (conn *HTTPSEapiConnection) Execute(commands []interface{},
+	params Parameters) (*JSONRPCResponse, error) {
+	if conn == nil {
+		return &JSONRPCResponse{}, fmt.Errorf("No connection")
+	}
+	conn.ClearError()
+	data, err := buildJSONRequest(commands, params)
+	if err != nil {
+		conn.SetError(err)
+		return &JSONRPCResponse{}, err
+	}
+	return conn.send(data)
 }
 
 // disableCertificateVerification disables https verification

--- a/examples/example1.go
+++ b/examples/example1.go
@@ -16,7 +16,7 @@ func main() {
 	fmt.Println(conf)
 
 	var showversion module.ShowVersion
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
 	if err := handle.Enable(&showversion); err != nil {
 		panic(err)
 	}

--- a/examples/example2.go
+++ b/examples/example2.go
@@ -39,7 +39,7 @@ func main() {
 
 	sv := &MyShowVlan{}
 
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
 	handle.AddCommand(sv)
 	if err := handle.Call(); err != nil {
 		panic(err)

--- a/examples/example4.go
+++ b/examples/example4.go
@@ -32,7 +32,7 @@ func main() {
 
 	svRsp := &showVersionResp{}
 
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
 	handle.AddCommand(svRsp)
 	if err := handle.Call(); err != nil {
 		panic(err)

--- a/examples/example5.go
+++ b/examples/example5.go
@@ -98,7 +98,7 @@ func main() {
 	shVlanRsp := &showVlan{}
 	shIntRsp := &showInterfacesStatus{}
 
-	handle, _ := node.GetHandle("json")
+	handle, _ := node.GetHandle(goeapi.Parameters{Format: "json"})
 	handle.AddCommand(shVerRsp)
 	handle.AddCommand(shHostnameRsp)
 	handle.AddCommand(shVlanRsp)

--- a/export_test.go
+++ b/export_test.go
@@ -86,7 +86,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string, streaming bool) (*JSONRPCResponse, error) {
+	encoding string) (*JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")
@@ -116,6 +116,12 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 	}
 
 	return resp, nil
+}
+
+func (conn *DummyEapiConnection) Stream(commands []interface{},
+	encoding string) (*JSONRPCResponse, error) {
+
+	return conn.Execute(commands, encoding)
 }
 
 func (conn *DummyEapiConnection) setReturnError(enable bool) {

--- a/export_test.go
+++ b/export_test.go
@@ -86,7 +86,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	params Parameters) (*JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")
@@ -100,7 +100,7 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 		Result: make([]map[string]interface{}, len(commands)),
 	}
 
-	if encoding == "json" {
+	if params.Format == "json" {
 		return resp, nil
 	}
 
@@ -109,7 +109,7 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 		resp.Result[idx]["output"] = ""
 	}
 
-	if encoding == "text" && len(commands) >= 2 &&
+	if params.Format == "text" && len(commands) >= 2 &&
 		(commands[1] == "show running-config all" ||
 			commands[1] == "show startup-config") {
 		resp.Result[1]["output"] = LoadFixtureFile("running_config.text")
@@ -119,9 +119,9 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 }
 
 func (conn *DummyEapiConnection) Stream(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	params Parameters) (*JSONRPCResponse, error) {
 
-	return conn.Execute(commands, encoding)
+	return conn.Execute(commands, params)
 }
 
 func (conn *DummyEapiConnection) setReturnError(enable bool) {

--- a/export_test.go
+++ b/export_test.go
@@ -86,7 +86,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, streaming bool) (*JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")

--- a/module/arp.go
+++ b/module/arp.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowARP struct {
 	DynamicEntries    int            `json:"dynamicEntries"`
 	IPv4Neighbors     []IPv4Neighbor `json:"ipV4Neighbors"`
@@ -54,7 +56,7 @@ func (a *ShowARP) GetCmd() string {
 func (s *ShowEntity) ShowARP() (ShowARP, error) {
 	var showarp ShowARP
 
-	handle, err := s.node.GetHandle("json")
+	handle, err := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	if err != nil {
 		return showarp, err
 	}

--- a/module/bgp.go
+++ b/module/bgp.go
@@ -759,7 +759,7 @@ func (b *ShowIPBGPSummary) GetCmd() string {
 }
 
 func (s *ShowEntity) ShowIPBGPSummary() (ShowIPBGPSummary, error) {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showipbgpsummary ShowIPBGPSummary
 	handle.AddCommand(&showipbgpsummary)
 

--- a/module/dummy_connection_test.go
+++ b/module/dummy_connection_test.go
@@ -16,7 +16,7 @@ type DummyConnection struct {
 }
 
 func (conn *DummyConnection) Execute(commands []interface{},
-	encoding string, streaming bool) (*goeapi.JSONRPCResponse, error) {
+	encoding string) (*goeapi.JSONRPCResponse, error) {
 
 	if encoding != "json" {
 		return nil, fmt.Errorf("%s encoding not implemented", encoding)
@@ -38,6 +38,12 @@ func (conn *DummyConnection) Execute(commands []interface{},
 	}
 	defer r.Close()
 	return conn.decodeJSONFile(r), nil
+}
+
+func (conn *DummyConnection) Stream(commands []interface{},
+	encoding string) (*goeapi.JSONRPCResponse, error) {
+
+	return conn.Execute(commands, encoding)
 }
 
 func (conn *DummyConnection) SetTimeout(uint32) {

--- a/module/dummy_connection_test.go
+++ b/module/dummy_connection_test.go
@@ -16,10 +16,10 @@ type DummyConnection struct {
 }
 
 func (conn *DummyConnection) Execute(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
+	params goeapi.Parameters) (*goeapi.JSONRPCResponse, error) {
 
-	if encoding != "json" {
-		return nil, fmt.Errorf("%s encoding not implemented", encoding)
+	if params.Format != "json" {
+		return nil, fmt.Errorf("%s encoding not implemented", params.Format)
 	}
 
 	if conn.err != nil {
@@ -38,12 +38,6 @@ func (conn *DummyConnection) Execute(commands []interface{},
 	}
 	defer r.Close()
 	return conn.decodeJSONFile(r), nil
-}
-
-func (conn *DummyConnection) Stream(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
-
-	return conn.Execute(commands, encoding)
 }
 
 func (conn *DummyConnection) SetTimeout(uint32) {

--- a/module/dummy_connection_test.go
+++ b/module/dummy_connection_test.go
@@ -16,7 +16,7 @@ type DummyConnection struct {
 }
 
 func (conn *DummyConnection) Execute(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
+	encoding string, streaming bool) (*goeapi.JSONRPCResponse, error) {
 
 	if encoding != "json" {
 		return nil, fmt.Errorf("%s encoding not implemented", encoding)

--- a/module/environment.go
+++ b/module/environment.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowEnvironmentPower struct {
 	PowerSupplies map[string]struct {
 		OutputPower  float64 `json:"outputPower"`
@@ -58,7 +60,7 @@ func (b *ShowEnvironmentPower) GetCmd() string {
 }
 
 func (s *ShowEntity) ShowEnvironmentPower() (ShowEnvironmentPower, error) {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showenvironmentpower ShowEnvironmentPower
 	handle.AddCommand(&showenvironmentpower)
 

--- a/module/export_test.go
+++ b/module/export_test.go
@@ -137,7 +137,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
+	params goeapi.Parameters) (*goeapi.JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")
@@ -151,7 +151,7 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 		Result: make([]map[string]interface{}, len(commands)),
 	}
 
-	if encoding == "json" {
+	if params.Format == "json" {
 		return resp, nil
 	}
 
@@ -160,7 +160,7 @@ func (conn *DummyEapiConnection) Execute(commands []interface{},
 		resp.Result[idx]["output"] = ""
 	}
 
-	if encoding == "text" && len(commands) >= 2 &&
+	if params.Format == "text" && len(commands) >= 2 &&
 		(commands[1] == "show running-config all" ||
 			commands[1] == "show startup-config") {
 		resp.Result[1]["output"] = LoadFixtureFile("running_config.text")

--- a/module/export_test.go
+++ b/module/export_test.go
@@ -137,7 +137,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string, streaming bool) (*goeapi.JSONRPCResponse, error) {
+	encoding string) (*goeapi.JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")

--- a/module/export_test.go
+++ b/module/export_test.go
@@ -137,7 +137,7 @@ func NewDummyEapiConnection(transport string, host string, username string,
 }
 
 func (conn *DummyEapiConnection) Execute(commands []interface{},
-	encoding string) (*goeapi.JSONRPCResponse, error) {
+	encoding string, streaming bool) (*goeapi.JSONRPCResponse, error) {
 	if conn.retError {
 		conn.retError = false
 		err := fmt.Errorf("Mock Error")

--- a/module/interfaces_switchport.go
+++ b/module/interfaces_switchport.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowInterfacesSwitchport struct {
 	Switchports map[string]Switchport `json:"switchports"`
 }
@@ -61,7 +63,7 @@ func (l *ShowInterfacesSwitchport) GetCmd() string {
 }
 
 func (s *ShowEntity) ShowInterfacesSwitchport() ShowInterfacesSwitchport {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showInterfacesSwitchport ShowInterfacesSwitchport
 	handle.AddCommand(&showInterfacesSwitchport)
 	handle.Call()

--- a/module/iproute.go
+++ b/module/iproute.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowIPRoute struct {
 	VRFs map[string]Routes `json:"vrfs"`
 }
@@ -59,7 +61,7 @@ func (r *ShowIPRoute) GetCmd() string {
 }
 
 func (s *ShowEntity) ShowIPRoute() ShowIPRoute {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showiproute ShowIPRoute
 	handle.AddCommand(&showiproute)
 	handle.Call()

--- a/module/lldp.go
+++ b/module/lldp.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowLLDPNeighbors struct {
 	TablesLastChangeTime float64        `json:"tablesLastChangeTime"`
 	TablesAgeouts        int            `json:"tablesAgeOuts"`
@@ -53,7 +55,7 @@ func (l *ShowLLDPNeighbors) GetCmd() string {
 }
 
 func (s *ShowEntity) ShowLLDPNeighbors() ShowLLDPNeighbors {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showlldpneighbors ShowLLDPNeighbors
 	handle.AddCommand(&showlldpneighbors)
 	handle.Call()

--- a/module/macaddress.go
+++ b/module/macaddress.go
@@ -32,6 +32,8 @@
 
 package module
 
+import "github.com/aristanetworks/goeapi"
+
 type ShowMACAddressTable struct {
 	MulticastTable struct {
 		TableEntries []MACAddressTableEntry `json:"tableEntries"`
@@ -57,7 +59,7 @@ func (a *ShowMACAddressTable) GetCmd() string {
 func (s *ShowEntity) ShowMACAddressTable() (ShowMACAddressTable, error) {
 	var showmacaddresstable ShowMACAddressTable
 
-	handle, err := s.node.GetHandle("json")
+	handle, err := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	if err != nil {
 		return showmacaddresstable, err
 	}

--- a/module/ptp.go
+++ b/module/ptp.go
@@ -287,7 +287,7 @@ func (b *ShowPTP) GetCmd() string {
 
 func (s *ShowEntity) ShowPTP() (ShowPTP, error) {
 	var showptp ShowPTP
-	handle, err := s.node.GetHandle("json")
+	handle, err := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	if err != nil {
 		return showptp, err
 	}

--- a/module/version.go
+++ b/module/version.go
@@ -186,7 +186,7 @@ func Show(node *goeapi.Node) *ShowEntity {
 // (with "json" key in the struct field's tag value) for the
 // decoded response from 'show version' command
 func (s *ShowEntity) ShowVersion() ShowVersion {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showversion ShowVersion
 	handle.AddCommand(&showversion)
 	handle.Call()
@@ -198,7 +198,7 @@ func (s *ShowEntity) ShowVersion() ShowVersion {
 // (with "json" key in the struct field's tag value) for the
 // decoded response from 'show interfaces' command
 func (s *ShowEntity) ShowInterfaces() ShowInterface {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showinterface ShowInterface
 	handle.AddCommand(&showinterface)
 	handle.Call()
@@ -210,7 +210,7 @@ func (s *ShowEntity) ShowInterfaces() ShowInterface {
 // (with "json" key in the struct field's tag value) for the
 // decoded response from 'show vlan trunk group' command
 func (s *ShowEntity) ShowTrunkGroups() ShowTrunkGroup {
-	handle, _ := s.node.GetHandle("json")
+	handle, _ := s.node.GetHandle(goeapi.Parameters{Format: "json"})
 	var showTrunkGroups ShowTrunkGroup
 	handle.AddCommand(&showTrunkGroups)
 	handle.Call()


### PR DESCRIPTION
eAPI has a hidden JSONPRC parameter that prevents long-running requests from timing out.  I've made these changes to implement this feature

cURL example for reference:

```
> wget -q -O - http://admin:@tg251/command-api --post-data='{ "jsonrpc": "2.0",
   "method": "runCmds",
   "streaming": true,  <<<<=============
   "params": {
      "version": 1,
      "cmds": ["enable",
               "show ip route vrf all"],
      "format": "json"
   },
   "id": "1"
}'
```