### PR TITLE
Support user ssh-key in 4.23+ images

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,6 +62,7 @@ type Node struct {
 	startupConfig string
 	autoRefresh   bool
 	enablePasswd  string
+	versionNumber string
 }
 
 // GetConnection returns the EapiConnectionEntity
@@ -279,6 +280,31 @@ func (n *Node) ConfigWithErr(commands ...string) error {
 func (n *Node) Config(commands ...string) bool {
 	err := n.ConfigWithErr(commands...)
 	return (err == nil)
+}
+
+// Return the EOS version for this node
+//
+// This method is used to return the current version of the running node.
+func (n *Node) Version() string {
+	return n.versionNumber
+}
+
+func (n *Node) getVersionNumber() error {
+	result, err := n.RunCommands([]string{"show version"}, "json")
+	if err != nil {
+		return fmt.Errorf("getVersionNumber: %v", err)
+	}
+	versionMap, found := result.Result[0]["version"]
+	if !found {
+		return fmt.Errorf("getVersionNumber: version not found")
+	}
+	version, ok := versionMap.(string)
+	if !ok {
+		return fmt.Errorf("getVersionNumber: Expect type 'string',  got '%T'",
+			versionMap)
+	}
+	n.versionNumber = version
+	return nil
 }
 
 // Enable issues an array of commands to the node in enable mode
@@ -683,6 +709,7 @@ func ConnectTo(name string) (*Node, error) {
 		return nil, err
 	}
 	node.EnableAuthentication(enablepwd)
+	node.getVersionNumber()
 	return node, nil
 }
 
@@ -713,7 +740,10 @@ func Connect(transport string, host string, username string, passwd string,
 	if err != nil {
 		return nil, err
 	}
-	return &Node{conn: conn, autoRefresh: true}, nil
+	node := &Node{conn: conn, autoRefresh: true}
+	node.getVersionNumber()
+
+	return node, nil
 }
 
 // Connection creates a connection using the supplied settings

--- a/client.go
+++ b/client.go
@@ -282,13 +282,13 @@ func (n *Node) Config(commands ...string) bool {
 	return (err == nil)
 }
 
-// Return the EOS version for this node
-//
-// This method is used to return the current version of the running node.
+// Version returns the EOS version for this node
 func (n *Node) Version() string {
 	return n.versionNumber
 }
 
+// getVersionNumber is used to populate the versionNumber for this node. This
+// is called during the Connect.
 func (n *Node) getVersionNumber() error {
 	result, err := n.RunCommands([]string{"show version"}, "json")
 	if err != nil {
@@ -709,6 +709,7 @@ func ConnectTo(name string) (*Node, error) {
 		return nil, err
 	}
 	node.EnableAuthentication(enablepwd)
+	// Populate the versionNumber for this node
 	node.getVersionNumber()
 	return node, nil
 }
@@ -741,6 +742,7 @@ func Connect(transport string, host string, username string, passwd string,
 		return nil, err
 	}
 	node := &Node{conn: conn, autoRefresh: true}
+	// Populate the versionNumber for this node
 	node.getVersionNumber()
 
 	return node, nil

--- a/module/abstract.go
+++ b/module/abstract.go
@@ -63,6 +63,13 @@ func (b *AbstractBaseEntity) Config() string {
 	return b.node.RunningConfig()
 }
 
+// Version returns the current running version
+// Returns:
+//      String: version
+func (b *AbstractBaseEntity) Version() string {
+	return b.node.Version()
+}
+
 // Error returns the current error exception
 // Returns:
 //      Error: current error

--- a/module/users.go
+++ b/module/users.go
@@ -54,7 +54,7 @@ var usersRegex = regexp.MustCompile(`(?m)username ([^\s]+) privilege (\d+)` +
 	`(?m)(?: role ([^\s]+))?` +
 	`(?m)(?: (nopassword))?` +
 	`(?m)(?: secret (0|5|7|sha512) (.+))?` +
-	`(?m).*$\n(?:username ([^\s]+) sshkey (.+)$)?`)
+	`(?m).*$\n(?:username ([^\s]+) ssh-?key (.+)$)?`)
 
 // UserConfig represents a parsed user entry containing:
 //
@@ -217,7 +217,7 @@ func parseUsername(config string) UserConfig {
 		`(?: role ([^\s]+))?` +
 		`(?: (nopassword))?` +
 		`(?: secret (0|5|7|sha512) (.+))?` +
-		`.*$\n(?:username ([^\s]+) sshkey (.+)$)?`)
+		`.*$\n(?:username ([^\s]+) ssh-?key (.+)$)?`)
 
 	var resource = make(UserConfig)
 
@@ -364,11 +364,18 @@ func (u *UserEntity) SetRole(name string, value string) bool {
 // Returns:
 //  True if the operation was successful otherwise False
 func (u *UserEntity) SetSshkey(name string, value string) bool {
+	versionRegex := regexp.MustCompile(`\d.\d+`)
+	versionNumber := versionRegex.FindString(u.Version())
+
+	sshkey := "ssh-key"
+	if versionNumber < "4.23" {
+		sshkey = "sshkey"
+	}
 	var cmd = "username " + name
 	if value != "" {
-		cmd = cmd + " sshkey " + value
+		cmd = cmd + " " + sshkey + " " + value
 	} else {
-		cmd = "no " + cmd + " sshkey"
+		cmd = "no " + cmd + " " + sshkey
 	}
 	return u.Configure(cmd)
 }

--- a/module/users_test.go
+++ b/module/users_test.go
@@ -224,6 +224,30 @@ func TestUsersParseUsername_UnitTest(t *testing.T) {
 				"sshkey":     "",
 			},
 		},
+		{
+			"username test-user privilege 15 role network-admin nopassword\nusername test-user sshkey ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEFqQxWvCw3wbD4iIY9qOO2WojYgRd3UwzA0jcdCB0Lv6mYEuup+kKmQa/88EzgAnvzPxJmn85ma+RqDGEcVQB4fO3tnyV7Fbm6PkzK1TLuQ9oDu6/m6Q+/hSjf4VXPA1OcVA8DqZMF6IoeJoWRffTXzPOonNlpbHAZTqLP0NBcAZj0Uhm2COgfRTqwHLnVH9zVemviRGeufV6smbbZ9/lY5+AOT3GNC9V/5nECxI3rx6Iw/Zz1KOmv1OyaEogEbqdhAs1DwzgXaEjh5HtoLPGtDb30xpCimlID5b3C5V1rlwx+LLt5pPStHwpr3vpCjAiRXoNOl+v9i19cXbkPZ35 test-user@moon\n",
+			UserConfig{
+				"username":   "test-user",
+				"privilege":  "15",
+				"role":       "network-admin",
+				"nopassword": "true",
+				"format":     "",
+				"secret":     "",
+				"sshkey":     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEFqQxWvCw3wbD4iIY9qOO2WojYgRd3UwzA0jcdCB0Lv6mYEuup+kKmQa/88EzgAnvzPxJmn85ma+RqDGEcVQB4fO3tnyV7Fbm6PkzK1TLuQ9oDu6/m6Q+/hSjf4VXPA1OcVA8DqZMF6IoeJoWRffTXzPOonNlpbHAZTqLP0NBcAZj0Uhm2COgfRTqwHLnVH9zVemviRGeufV6smbbZ9/lY5+AOT3GNC9V/5nECxI3rx6Iw/Zz1KOmv1OyaEogEbqdhAs1DwzgXaEjh5HtoLPGtDb30xpCimlID5b3C5V1rlwx+LLt5pPStHwpr3vpCjAiRXoNOl+v9i19cXbkPZ35 test-user@moon",
+			},
+		},
+		{
+			"username test-user privilege 15 role network-admin nopassword\nusername test-user ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEFqQxWvCw3wbD4iIY9qOO2WojYgRd3UwzA0jcdCB0Lv6mYEuup+kKmQa/88EzgAnvzPxJmn85ma+RqDGEcVQB4fO3tnyV7Fbm6PkzK1TLuQ9oDu6/m6Q+/hSjf4VXPA1OcVA8DqZMF6IoeJoWRffTXzPOonNlpbHAZTqLP0NBcAZj0Uhm2COgfRTqwHLnVH9zVemviRGeufV6smbbZ9/lY5+AOT3GNC9V/5nECxI3rx6Iw/Zz1KOmv1OyaEogEbqdhAs1DwzgXaEjh5HtoLPGtDb30xpCimlID5b3C5V1rlwx+LLt5pPStHwpr3vpCjAiRXoNOl+v9i19cXbkPZ35 test-user@moon\n",
+			UserConfig{
+				"username":   "test-user",
+				"privilege":  "15",
+				"role":       "network-admin",
+				"nopassword": "true",
+				"format":     "",
+				"secret":     "",
+				"sshkey":     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEFqQxWvCw3wbD4iIY9qOO2WojYgRd3UwzA0jcdCB0Lv6mYEuup+kKmQa/88EzgAnvzPxJmn85ma+RqDGEcVQB4fO3tnyV7Fbm6PkzK1TLuQ9oDu6/m6Q+/hSjf4VXPA1OcVA8DqZMF6IoeJoWRffTXzPOonNlpbHAZTqLP0NBcAZj0Uhm2COgfRTqwHLnVH9zVemviRGeufV6smbbZ9/lY5+AOT3GNC9V/5nECxI3rx6Iw/Zz1KOmv1OyaEogEbqdhAs1DwzgXaEjh5HtoLPGtDb30xpCimlID5b3C5V1rlwx+LLt5pPStHwpr3vpCjAiRXoNOl+v9i19cXbkPZ35 test-user@moon",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes issue #49

* Proactively collect the EOS version during Connect
* Added Node method and module/abstract method to get Version
* Updated regex to account for '-' in ssh-key field
* Update SetSshkey() to revert to older 'sshkey' field name for EOS
   versions < 4.23