### PR TITLE
hacking in a way the capability of using eapi version 1 or "latest"

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ type Node struct {
 	autoRefresh   bool
 	enablePasswd  string
 	versionNumber string
-	eAPIVersion	  string
+	eAPIVersion   string
 }
 
 // GetConnection returns the EapiConnectionEntity

--- a/client.go
+++ b/client.go
@@ -63,6 +63,7 @@ type Node struct {
 	autoRefresh   bool
 	enablePasswd  string
 	versionNumber string
+	eAPIVersion	  string
 }
 
 // GetConnection returns the EapiConnectionEntity
@@ -154,15 +155,18 @@ func (n *Node) Refresh() {
 //
 // Returns:
 //  Pointer to an EapiReqHandle or error on failure
-func GetHandle(n *Node, encoding string) (*EapiReqHandle, error) {
+func GetHandle(n *Node, encoding string, version StringOrInt) (*EapiReqHandle, error) {
 	if strings.ToLower(encoding) != "json" &&
 		strings.ToLower(encoding) != "text" {
 		return nil, fmt.Errorf("Invalid encoding specified: %s", encoding)
 	}
+	if version == nil {
+		version = 1
+	}
 	if n == nil {
 		return nil, fmt.Errorf("Invalid node")
 	}
-	return &EapiReqHandle{node: n, encoding: encoding}, nil
+	return &EapiReqHandle{node: n, encoding: encoding, version:version}, nil
 }
 
 // GetHandle returns the EapiReqHandle for the connection.
@@ -172,8 +176,11 @@ func GetHandle(n *Node, encoding string) (*EapiReqHandle, error) {
 //
 // Returns:
 //  Pointer to an EapiReqHandle or error on failure
-func (n *Node) GetHandle(encoding string) (*EapiReqHandle, error) {
-	return GetHandle(n, encoding)
+func (n *Node) GetHandle(encoding string, version ...StringOrInt) (*EapiReqHandle, error) {
+	if version == nil {
+		return GetHandle(n, encoding, 1)
+	} 
+	return GetHandle(n, encoding, version[0])
 }
 
 // GetConfig retrieves the config from the node.
@@ -373,7 +380,7 @@ func (n *Node) RunCommands(commands []string,
 		cmds = cmdsToInterface(commands)
 	}
 
-	result, err := n.conn.Execute(cmds, encoding)
+	result, err := n.conn.Execute(cmds, encoding, n.eAPIVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/eapi.go
+++ b/eapi.go
@@ -55,8 +55,10 @@ type Request struct {
 }
 
 // Parameters ...
+type StringOrInt interface{}
+
 type Parameters struct {
-	Version int           `json:"version"`
+	Version StringOrInt   `json:"version"`
 	Cmds    []interface{} `json:"cmds"`
 	Format  string        `json:"format"`
 }
@@ -107,6 +109,7 @@ type EapiReqHandle struct {
 	encoding     string
 	eapiCommands []commandBlock
 	err          error
+	version		 StringOrInt
 }
 
 // debugJSON prints out []byte JSON data Indented
@@ -250,7 +253,7 @@ func (handle *EapiReqHandle) Call() error {
 
 	commands := handle.getAllCommands()
 
-	jsonrsp, err := handle.node.conn.Execute(commands, handle.encoding)
+	jsonrsp, err := handle.node.conn.Execute(commands, handle.encoding, handle.version)
         
 	if err != nil {
 		return err

--- a/eapilib.go
+++ b/eapilib.go
@@ -49,7 +49,7 @@ import (
 // EapiConnectionEntity is an interface representing the ability to execute a
 // single json transaction, obtaining the Response for a given Request.
 type EapiConnectionEntity interface {
-	Execute(commands []interface{}, encoding string) (*JSONRPCResponse, error)
+	Execute(commands []interface{}, encoding string, version StringOrInt) (*JSONRPCResponse, error)
 	SetTimeout(to uint32)
 	SetDisableKeepAlive(disableKeepAlive bool)
 	Error() error
@@ -81,7 +81,7 @@ type EapiConnection struct {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *EapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, version StringOrInt) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
@@ -167,8 +167,8 @@ func (conn *EapiConnection) SetDisableKeepAlive(disableKeepAlive bool) {
 // entries both can be used. Returns []byte of the built JSON request.
 // Successful call returns err == nil.
 func buildJSONRequest(commands []interface{},
-	encoding string, reqid string) ([]byte, error) {
-	p := Parameters{1, commands, encoding}
+	encoding string, reqid string, version StringOrInt) ([]byte, error) {
+	p := Parameters{version, commands, encoding}
 
 	req := Request{"2.0", "runCmds", p, reqid}
 	data, err := json.Marshal(req)
@@ -273,12 +273,12 @@ func (conn *SocketEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *SocketEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, version StringOrInt) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()), version)
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -356,12 +356,12 @@ func (conn *HTTPLocalEapiConnection) send(data []byte) (*JSONRPCResponse, error)
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPLocalEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, version StringOrInt) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()), version)
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -465,12 +465,12 @@ func (conn *HTTPEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, version StringOrInt) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()), version)
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err
@@ -582,12 +582,12 @@ func (conn *HTTPSEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 // Returns:
 //  pointer to JSONRPCResponse or error on failure
 func (conn *HTTPSEapiConnection) Execute(commands []interface{},
-	encoding string) (*JSONRPCResponse, error) {
+	encoding string, version StringOrInt) (*JSONRPCResponse, error) {
 	if conn == nil {
 		return &JSONRPCResponse{}, fmt.Errorf("No connection")
 	}
 	conn.ClearError()
-	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()))
+	data, err := buildJSONRequest(commands, encoding, strconv.Itoa(os.Getpid()), version)
 	if err != nil {
 		conn.SetError(err)
 		return &JSONRPCResponse{}, err

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aristanetworks/goeapi
+module github.com/kalebris/goeapi-version-parm
 
 go 1.17
 


### PR DESCRIPTION
This PR is to overcome the issue of "version" being hardcoded into every jsonrpc request. This PR is meant to remedy this by allowing to pass version (string or int) to GetHandle, thus allowing to execute "latest" versioned eAPI requests.