### PR TITLE
Fix tls handshake failure with go1.22

### DIFF
--- a/eapilib.go
+++ b/eapilib.go
@@ -535,8 +535,15 @@ func (conn *HTTPSEapiConnection) send(data []byte) (*JSONRPCResponse, error) {
 	}
 	timeOut := time.Duration(time.Duration(conn.timeOut) * time.Second)
 	url := conn.getURL()
+	suites := []uint16{}
+	for _, suite := range tls.InsecureCipherSuites() {
+		suites = append(suites, suite.ID)
+	}
 	tr := &http.Transport{
-		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			CipherSuites:       suites,
+		},
 		DisableKeepAlives: conn.disableKeepAlive,
 	}
 	client := &http.Client{


### PR DESCRIPTION
RSA KEX cipher suites has been marked insecure in go1.22. See https://github.com/golang/go/commit/dc5a0d276bbcd6120325c9e0f9c8fd099fa2b8d6