### PR TITLE
Client timeout test now avoids internet access

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -33,6 +33,7 @@ package goeapi
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"regexp"
@@ -460,8 +461,14 @@ func TestClientConnectInvalidTransport_UnitTest(t *testing.T) {
 }
 
 func TestClientConnectTimeout_UnitTest(t *testing.T) {
-	// 1.1.1.2 is assumed to be an unreachable bogus address
-	node, err := Connect("http", "1.1.1.2", "admin", "admin", 80)
+	// We create a local socket that never gives any responses
+	// We assume that 127.0.0.1 exists as the loopback on the test host.
+	sock, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal("Error in test setup (listen).")
+	}
+	port := sock.Addr().(*net.TCPAddr).Port
+	node, err := Connect("http", "127.0.0.1", "admin", "admin", port)
 	if err != nil {
 		t.Fatal("Error in connect.")
 	}
@@ -470,6 +477,7 @@ func TestClientConnectTimeout_UnitTest(t *testing.T) {
 	if _, err = node.getConfigText("running-config", "all"); err == nil {
 		t.Fatal("Should timeout and return error")
 	}
+	sock.Close()
 }
 
 func TestClientConnectDefaultPort_UnitTest(t *testing.T) {


### PR DESCRIPTION
1.1.1.2, as defined in the current code, runs a port 80 web server that responds to HTTP requests. Thus the timeout code is not doing a timeout test, but rather testing against a web server that doesn't understand the Arista API.

This PR fixes that, but also exposes what I documented in #61 - I.E. that a hardcoded 60 second timeout exists in Connect(), thus client_test.go unit tests now take 65s to run, thus it may be a good idea to address #61 so that timeout on connect is configurable as well.