### PR TITLE
Fix queue_test.go by modifying incorrect json tags

### DIFF
--- a/module/queue.go
+++ b/module/queue.go
@@ -37,32 +37,34 @@ import "fmt"
 // ShowQueueMonitor represents "show queue-monitor length" output
 type ShowQueueMonitor struct {
 	Cmd                 string
-	ReportTime          float64  `json:"report_time"`
+	ReportTime          float64  `json:"reportTime"`
 	Warnings            string   `json:"warnings"`
-	BytesPerTxmpSegment uint     `json:"bytes_per_txmp_segment"`
-	GlobalHitCount      uint     `json:"global_hit_count"`
-	LanzEnabled         bool     `json:"lanz_enabled"`
-	PlatformName        string   `json:"platform_name"`
-	EntryList           []*Entry `json:"entry_list"`
+	BytesPerTxmpSegment uint     `json:"bytesPerTxmpSegment"`
+	GlobalHitCount      uint     `json:"globalHitCount"`
+	LanzEnabled         bool     `json:"lanzEnabled"`
+	PlatformName        string   `json:"platformName"`
+	EntryList           []*Entry `json:"entryList"`
 }
 
 // Entry is queueing event entry from the ShowQueueMonitor output:
 // Type       Time                    Intf(TC)           Queue         Duration      Ingress
-//                                                      Length                      Port-set
-//                                                      (bytes)       (usecs)
-//---------- ----------------------- --------------- ------------- ---------------- ------------------------------------------------
+//
+//	Length                      Port-set
+//	(bytes)       (usecs)
+//
+// ---------- ----------------------- --------------- ------------- ---------------- ------------------------------------------------
 // P          0:00:03.83243 ago       Et24/1(2)          41904         1000000       Et3/1,4/1,5/1,8/1,9/1,10/1,25/1,26/1,30/1
 type Entry struct {
-	EntryTimeUsecs              int64    `json:"entry_time_usecs"`
-	GlobalProtectionModeEnabled bool     `json:"global_protection_mode_enabled"`
-	EntryTime                   float64  `json:"entry_time"`
+	EntryTimeUsecs              int64    `json:"entryTimeUsecs"`
+	GlobalProtectionModeEnabled bool     `json:"globalProtectionModeEnabled"`
+	EntryTime                   float64  `json:"entryTime"`
 	Interface                   string   `json:"interface"`
 	Duration                    uint     `json:"duration"`
-	DurationUsecs               uint32   `json:"duration_usecs"`
-	EntryType                   string   `json:"entry_type"`
-	QueueLength                 uint32   `json:"queue_length"`
-	TrafficClass                uint     `json:"traffic_class"`
-	IngressPortSet              []string `json:"ingress_port_set"`
+	DurationUsecs               uint32   `json:"durationUsecs"`
+	EntryType                   string   `json:"entryType"`
+	QueueLength                 uint32   `json:"queueLength"`
+	TrafficClass                uint     `json:"trafficClass"`
+	IngressPortSet              []string `json:"ingressPortSet"`
 }
 
 func (l *ShowQueueMonitor) SetCmd(port string, limitBy string, limitValue int) {

--- a/module/queue_test.go
+++ b/module/queue_test.go
@@ -17,7 +17,10 @@ func TestShowQueueMonitor_UnitTest(t *testing.T) {
 	dummyNode.SetConnection(dummyConnection)
 
 	show := Show(dummyNode)
-	showqueue, _ := show.ShowQueueMonitor("Et24")
+	showqueue, err := show.ShowQueueMonitor("Et24")
+	if err != nil {
+		t.Errorf("Error during Show Queue, %s", err)
+	}
 
 	type ShowQueueMonitor struct {
 		Cmd                 string
@@ -150,6 +153,10 @@ func TestShowQueueMonitor_UnitTest(t *testing.T) {
 		if tt.PlatformName != showqueue.PlatformName {
 			t.Errorf("Platform name doesn't match expected %s, got %s", tt.PlatformName, showqueue.PlatformName)
 		}
+		if len(entries) < len(tt.EntryList) {
+			t.Errorf("Expected at least %d entries, but got %d", len(tt.EntryList), len(entries))
+			continue
+		}
 		for idx, entry := range tt.EntryList {
 			if entry.EntryTime != entries[idx].EntryTime {
 				t.Errorf("Entry time does not match expected %f, got %f",
@@ -180,6 +187,10 @@ func TestShowQueueMonitor_UnitTest(t *testing.T) {
 		}
 		if tt.PlatformName != showqueue.PlatformName {
 			t.Errorf("Platform name doesn't match expected %s, got %s", tt.PlatformName, showqueue.PlatformName)
+		}
+		if len(entries) < len(tt.EntryList) {
+			t.Errorf("Expected at least %d entries, but got %d", len(tt.EntryList), len(entries))
+			continue
 		}
 		for idx, entry := range tt.EntryList {
 			if entry.EntryTime != entries[idx].EntryTime {


### PR DESCRIPTION
The test suite `TestShowQueueMonitor_UnitTest` in queue_test.go, which was recently merged were failing,

```
Export_test.go
Connections:  [localhost dut]
--- FAIL: TestShowQueueMonitor_UnitTest (0.00s)
    queue_test.go:147: Lanz is disabled, which does not match expected true, got false
    queue_test.go:151: Platform name doesn't match expected Sand, got 
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 141 [running]:
testing.tRunner.func1.2({0x10502d8c0, 0x14000014390})
        /Users/roopesh/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /Users/roopesh/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1737 +0x334
panic({0x10502d8c0?, 0x14000014390?})
        /Users/roopesh/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/runtime/panic.go:787 +0x124
github.com/aristanetworks/goeapi/module.TestShowQueueMonitor_UnitTest(0x140004a68c0)
        /Users/roopesh/Desktop/projects/arista/goeapi/module/queue_test.go:154 +0x1028
testing.tRunner(0x140004a68c0, 0x1050552c8)
        /Users/roopesh/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
        /Users/roopesh/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1851 +0x374
FAIL    github.com/aristanetworks/goeapi/module 3.404s
FAIL
```

Upon debugging, I found that the json tags for the structs `ShowQueueMonitor` and `Entry` were incorrect.

```
type ShowQueueMonitor struct {
    Cmd                 string
    ReportTime          float64  json:"report_time"
    Warnings            string   json:"warnings"
    BytesPerTxmpSegment uint     json:"bytes_per_txmp_segment"
    GlobalHitCount      uint     json:"global_hit_count"
    LanzEnabled         bool     json:"lanz_enabled"
    PlatformName        string   json:"platform_name"
    EntryList           []*Entry json:"entry_list"
}
```

As you refer above, json tags were incorrect. For instance the following is the json output for the command,

```
dut#show queue-monitor length | json
{
    "lanzEnabled": true,
    "entryList": [],
    "globalHitCount": 0,
    "reportTime": 1741830218.242005,
    "bytesPerTxmpSegment": 16,
    "platformName": "Sand"
}
```

I modified them and now the test cases pass,

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestShowQueueMonitor_UnitTest$ github.com/aristanetworks/goeapi/module

Export_test.go
Connections:  [dut localhost]
=== RUN   TestShowQueueMonitor_UnitTest
--- PASS: TestShowQueueMonitor_UnitTest (0.00s)
PASS
ok      github.com/aristanetworks/goeapi/module (cached)
```

#30